### PR TITLE
feat: generalization around fetching data

### DIFF
--- a/examples/basic/pages/star-wars/@id/+onBeforeRender.ts
+++ b/examples/basic/pages/star-wars/@id/+onBeforeRender.ts
@@ -3,9 +3,11 @@ export default onBeforeRender
 import fetch from 'cross-fetch'
 import { filterMovieData } from '../filterMovieData'
 import type { PageContextBuiltIn } from 'vike-react/types'
-import type { MovieDetails } from '../types'
+import type { AdditionalPageContext, MovieDetails } from '../types'
 
-async function onBeforeRender(pageContext: PageContextBuiltIn) {
+async function onBeforeRender(
+  pageContext: PageContextBuiltIn
+): Promise<AdditionalPageContext<{ movie: MovieDetails }, { title: string }>> {
   const response = await fetch(`https://star-wars.brillout.com/api/films/${pageContext.routeParams.id}.json`)
   let movie = (await response.json()) as MovieDetails
 
@@ -17,11 +19,16 @@ async function onBeforeRender(pageContext: PageContextBuiltIn) {
 
   return {
     pageContext: {
+      // Will be passed as properties to the page's root React component.
       pageProps: {
         movie
       },
-      // The page's <title>
-      title
+
+      // Will be available in onRenderClient() and onRenderHtml().
+      additionalData: {
+        // The renderers will use this data as page's <title>
+        title
+      }
     }
   }
 }

--- a/examples/basic/pages/star-wars/index/+onBeforeRender.ts
+++ b/examples/basic/pages/star-wars/index/+onBeforeRender.ts
@@ -2,21 +2,26 @@ export default onBeforeRender
 
 import fetch from 'node-fetch'
 //import { filterMovieData } from '../filterMovieData'
-import type { Movie, MovieDetails } from '../types'
+import type { AdditionalPageContext, Movie, MovieDetails } from '../types'
 
 // export { prerender }
 
-async function onBeforeRender() {
+async function onBeforeRender(): Promise<AdditionalPageContext<{ movies: Movie[] }, { title: string }>> {
   const movies = await getStarWarsMovies()
   return {
     pageContext: {
+      // Will be passed as properties to the page's root React component.
       pageProps: {
         // We remove data we don't need because we pass `pageContext.movies` to
         // the client; we want to minimize what is sent over the network.
         movies: filterMoviesData(movies)
       },
-      // The page's <title>
-      title: getTitle(movies)
+
+      // Will be available in onRenderClient() and onRenderHtml().
+      additionalData: {
+        // The renderers will use this data as page's <title>
+        title: getTitle(movies)
+      }
     }
   }
 }

--- a/examples/basic/pages/star-wars/types.ts
+++ b/examples/basic/pages/star-wars/types.ts
@@ -1,3 +1,5 @@
+import type { AdditionalData as VikeReactAdditionalData } from 'vike-react/types'
+
 export type Movie = {
   id: string
   title: string
@@ -9,4 +11,22 @@ export type MovieDetails = {
   release_date: string
   director: string
   producer: string
+}
+
+// A page's onBeforeRender() hook can fetch data and return it as additional
+// page context. By default onBeforeRender() runs only on the server (see
+// https://github.com/brillout/vite-plugin-ssr/blob/3334463/vite-plugin-ssr/node/plugin/plugins/importUserCode/v1-design/getVikeConfig/configDefinitionsBuiltIn.ts#L35 )
+// however this data will also be passed to the client (see `passToClient` in
+// /vike-react/renderer/+config.ts).
+export type AdditionalPageContext<PageProps = {}, UserDefinedAdditionalData = {}> = {
+  pageContext: {
+    // Properties of the page's root React component.
+    pageProps: PageProps
+
+    // Additional data that is not passed to the page's root React component, but
+    // can e.g. be used by the renderer, e.g. see
+    // * /vike-react/renderer/onRenderClient.tsx
+    // * /vike-react/renderer/getTitle.ts
+    additionalData: VikeReactAdditionalData & UserDefinedAdditionalData
+  }
 }

--- a/vike-react/renderer/+config.ts
+++ b/vike-react/renderer/+config.ts
@@ -4,16 +4,16 @@ import type { Component } from './types'
 import type { Effect } from 'vite-plugin-ssr/types'
 
 export type Config = ConfigCore & {
-  /** React element rendered and appended into &lt;head>&lt;/head> */
+  /** React element rendered and appended into <head></head> */
   Head?: Component
   Layout?: Component
-  /** &lt;title>${title}&lt;/title> */
+  /** <title>${title}</title> */
   title?: string
-  /** &lt;meta name="description" content="${description}" /> */
+  /** <meta name="description" content="${description}" /> */
   description?: string
-  /** &lt;link rel="icon" href="${favicon}" /> */
+  /** <link rel="icon" href="${favicon}" /> */
   favicon?: string
-  /** &lt;html lang="${lang}">
+  /** <html lang="${lang}">
    *
    *  @default 'en'
    *
@@ -32,6 +32,13 @@ export type Config = ConfigCore & {
    */
   ssr?: boolean
   Page?: Component
+}
+
+// Data expected to be fetched and returned by a page's onBeforeRender() hook.
+// The renderers will make use of this data when rendering the page.
+export type AdditionalData = {
+  /** <title>${title}</title> - has precedence over the config */
+  title?: string
 }
 
 // Depending on the value of `config.meta.ssr`, set other config options' `env`
@@ -59,7 +66,13 @@ const toggleSsrRelatedConfig: Effect = ({ configDefinedAt, configValue }) => {
 export default {
   onRenderHtml: 'import:vike-react/renderer/onRenderHtml',
   onRenderClient: 'import:vike-react/renderer/onRenderClient',
-  passToClient: ['pageProps', 'title'],
+
+  // An page can define an onBeforeRender() hook to be run on the server, which
+  // can fetch data and return it as additional page context. Typically it will
+  // return the page's root React component's props and additional data that can
+  // be used by the renderers. See /examples/basic/pages/star-wars/types.ts
+  passToClient: ['pageProps', 'additionalData'],
+
   clientRouting: true,
   hydrationCanBeAborted: true,
   meta: {

--- a/vike-react/renderer/getTitle.ts
+++ b/vike-react/renderer/getTitle.ts
@@ -1,38 +1,33 @@
 export { getTitle }
 
-import type { ConfigEntries } from 'vite-plugin-ssr/types'
+import type { PageContext } from './types'
 import { isCallable } from './utils/isCallable.js'
 
-function getTitle(pageContext: {
-  title?: unknown
-  config: Record<string, unknown>
-  configEntries: ConfigEntries
-}): null | string {
-  if (pageContext.title) {
-    if (typeof pageContext.title !== 'string') {
-      throw new Error('pageContext.title should be a string')
-    }
-    return pageContext.title
-  } else {
-    const titleConfig = pageContext.configEntries.title?.[0]
-    if (!titleConfig) {
-      return null
-    }
-    const title = titleConfig.configValue
-    if (typeof title === 'string') {
-      return title
-    }
-    if (!title) {
-      return null
-    }
-    const { configDefinedAt } = titleConfig
-    if (isCallable(title)) {
-      const val = title(pageContext)
-      if (typeof val !== 'string') {
-        throw new Error(configDefinedAt + ' should return a string')
-      }
-      return val
-    }
-    throw new Error(configDefinedAt + ' should be a string or a function returning a string')
+// Get the page's title if defined, either from the additional data fetched by
+// the page's onBeforeRender() hook or from the config.
+function getTitle(pageContext: PageContext): null | string {
+  if (pageContext.additionalData?.title !== undefined) {
+    return pageContext.additionalData.title
   }
+
+  const titleConfig = pageContext.configEntries.title?.[0]
+  if (!titleConfig) {
+    return null
+  }
+  const title = titleConfig.configValue
+  if (typeof title === 'string') {
+    return title
+  }
+  if (!title) {
+    return null
+  }
+  const { configDefinedAt } = titleConfig
+  if (isCallable(title)) {
+    const val = title(pageContext)
+    if (typeof val !== 'string') {
+      throw new Error(configDefinedAt + ' should return a string')
+    }
+    return val
+  }
+  throw new Error(configDefinedAt + ' should be a string or a function returning a string')
 }

--- a/vike-react/renderer/types.ts
+++ b/vike-react/renderer/types.ts
@@ -9,7 +9,7 @@ import type {
   PageContextBuiltIn,
   PageContextBuiltInClientWithClientRouting as PageContextBuiltInClient
 } from 'vite-plugin-ssr/types'
-import type { Config } from './+config'
+import type { AdditionalData, Config } from './+config'
 import type { ReactElement } from 'react'
 
 // type Component = (props: Record<string, unknown>) => ReactElement
@@ -21,7 +21,13 @@ type WrapperComponent = ({ children }: { children: any }) => ReactElement
 
 export type PageContextCommon = {
   Page: Page
+
+  // Properties of the page's root React component.
   pageProps?: PageProps
+
+  // Additional data fetched by the page's onBeforeRender() hook.
+  additionalData?: AdditionalData
+
   config: {
     Layout?: WrapperComponent
     Wrapper?: WrapperComponent

--- a/vike-react/types.d.ts
+++ b/vike-react/types.d.ts
@@ -2,4 +2,4 @@ export type {
   PageContextBuiltIn,
   PageContextBuiltInClientWithClientRouting as PageContextBuiltInClient
 } from 'vite-plugin-ssr/types'
-export type { ConfigEnhanced as Config } from './renderer/+config'
+export type { AdditionalData, ConfigEnhanced as Config } from './renderer/+config'


### PR DESCRIPTION
Added value:
1. if the use wants to define something else than `title`, they don't need us to extend the `passToClient` list anymore.
2. return types for `onBeforeRender()`
3. comments