### PR TITLE
Use interface merging

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -15,7 +15,7 @@
     "typescript": "^5.0.2",
     "vike-react": "0.1.6",
     "vite": "^4.3.8",
-    "vite-plugin-ssr": "^0.4.140"
+    "vite-plugin-ssr": "0.4.140-commit-894c039"
   },
   "type": "module"
 }

--- a/examples/basic/pages/+config.h.ts
+++ b/examples/basic/pages/+config.h.ts
@@ -1,4 +1,4 @@
-import type { Config } from 'vike-react/types'
+import type { Config } from 'vite-plugin-ssr/types'
 import Layout from '../layouts/LayoutDefault'
 import Head from '../layouts/HeadDefault'
 import logoUrl from '../assets/logo.svg'

--- a/examples/ssr-spa/package.json
+++ b/examples/ssr-spa/package.json
@@ -13,7 +13,7 @@
     "typescript": "^5.0.2",
     "vike-react": "0.1.6",
     "vite": "^4.3.8",
-    "vite-plugin-ssr": "^0.4.140"
+    "vite-plugin-ssr": "0.4.140-commit-894c039"
   },
   "type": "module"
 }

--- a/examples/ssr-spa/pages/+config.h.ts
+++ b/examples/ssr-spa/pages/+config.h.ts
@@ -1,4 +1,4 @@
-import type { Config } from 'vike-react/types'
+import type { Config } from 'vite-plugin-ssr/types'
 import Layout from '../layouts/LayoutDefault'
 import Head from '../layouts/HeadDefault'
 import logoUrl from '../assets/logo.svg'

--- a/examples/ssr-spa/pages/spa/+config.h.ts
+++ b/examples/ssr-spa/pages/spa/+config.h.ts
@@ -1,4 +1,4 @@
-import type { Config } from 'vike-react/types'
+import type { Config } from 'vite-plugin-ssr/types'
 
 export default {
   ssr: false // SPA

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
         specifier: ^4.3.8
         version: 4.3.8(@types/node@18.15.3)
       vite-plugin-ssr:
-        specifier: ^0.4.140
-        version: 0.4.140(vite@4.3.8)
+        specifier: 0.4.140-commit-894c039
+        version: 0.4.140-commit-894c039(vite@4.3.8)
 
   examples/ssr-spa:
     dependencies:
@@ -74,8 +74,8 @@ importers:
         specifier: ^4.3.8
         version: 4.3.8(@types/node@18.15.3)
       vite-plugin-ssr:
-        specifier: ^0.4.140
-        version: 0.4.140(vite@4.3.8)
+        specifier: 0.4.140-commit-894c039
+        version: 0.4.140-commit-894c039(vite@4.3.8)
 
   vike-react:
     dependencies:
@@ -83,8 +83,8 @@ importers:
         specifier: ^4.3.8
         version: 4.3.8(@types/node@18.15.3)
       vite-plugin-ssr:
-        specifier: ^0.4.140
-        version: 0.4.140(vite@4.3.8)
+        specifier: 0.4.140-commit-894c039
+        version: 0.4.140-commit-894c039(vite@4.3.8)
     devDependencies:
       '@brillout/release-me':
         specifier: ^0.1.3
@@ -2130,8 +2130,8 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-plugin-ssr@0.4.140(vite@4.3.8):
-    resolution: {integrity: sha512-UcUOszxAdf2Kau4VbVeNRZwVvINtrQIuI8NzuwXXW41nq2f2ej9T/+8uRF6ICUi99Y0HwiK1kZX0+Ox7oY17gg==}
+  /vite-plugin-ssr@0.4.140-commit-894c039(vite@4.3.8):
+    resolution: {integrity: sha512-d9OQJtlIXtMHHOQebcw5OTfyZFTgHBqHsuPiw+yfuTG5a+z7gOOoGQu0HWl7yrehoB1JcYVmv3mPuOZlAtNEbQ==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     peerDependencies:

--- a/vike-react/package.json
+++ b/vike-react/package.json
@@ -20,7 +20,7 @@
     "react": "18.x.x",
     "react-dom": "18.x.x",
     "vite": "^4.3.8",
-    "vite-plugin-ssr": "^0.4.140"
+    "vite-plugin-ssr": "0.4.140-commit-894c039"
   },
   "devDependencies": {
     "@brillout/release-me": "^0.1.3",

--- a/vike-react/renderer/+config.ts
+++ b/vike-react/renderer/+config.ts
@@ -1,43 +1,9 @@
-import type { Config as ConfigCore } from 'vite-plugin-ssr/types'
-import type { Component } from './types'
-
-import type { Effect } from 'vite-plugin-ssr/types'
-
-export type Config = ConfigCore & {
-  /** React element rendered and appended into <head></head> */
-  Head?: Component
-  Layout?: Component
-  /** <title>${title}</title> */
-  title?: string
-  /** <meta name="description" content="${description}" /> */
-  description?: string
-  /** <link rel="icon" href="${favicon}" /> */
-  favicon?: string
-  /** <html lang="${lang}">
-   *
-   *  @default 'en'
-   *
-   */
-  lang?: string
-  /**
-   * If true, render mode is SSR or pre-rendering (aka SSG). In other words, the
-   * page's HTML will be rendered at build-time or request-time.
-   * If false, render mode is SPA. In other words, the page will only be
-   * rendered in the browser.
-   *
-   * See https://vite-plugin-ssr.com/render-modes
-   *
-   * @default true
-   *
-   */
-  ssr?: boolean
-  Page?: Component
-}
+import type { Config, ConfigEffect, ConfigVikeReact } from 'vite-plugin-ssr/types'
 
 // Depending on the value of `config.meta.ssr`, set other config options' `env`
 // accordingly.
 // See https://vite-plugin-ssr.com/meta#modify-existing-configurations
-const toggleSsrRelatedConfig: Effect = ({ configDefinedAt, configValue }) => {
+const toggleSsrRelatedConfig: ConfigEffect = ({ configDefinedAt, configValue }) => {
   if (typeof configValue !== 'boolean') {
     throw new Error(`${configDefinedAt} should be a boolean`)
   }
@@ -86,4 +52,39 @@ export default {
       effect: toggleSsrRelatedConfig
     }
   }
-} satisfies ConfigCore
+} satisfies Config & ConfigVikeReact
+
+// We purposely define the ConfigVikeReact interface in this file: that way we ensure it's always applied whenever the user `import vikeReact from 'vike-react'`
+import type { Component } from './types'
+declare module 'vite-plugin-ssr/types' {
+  export interface ConfigVikeReact {
+    /** React element rendered and appended into &lt;head>&lt;/head> */
+    Head?: Component
+    /** A component, usually common to several pages, that wraps the root component `Page` */
+    Layout?: Component
+    /** &lt;title>${title}&lt;/title> */
+    title?: string
+    /** &lt;meta name="description" content="${description}" /> */
+    description?: string
+    /** &lt;link rel="icon" href="${favicon}" /> */
+    favicon?: string
+    /** &lt;html lang="${lang}">
+     *
+     *  @default 'en'
+     *
+     */
+    lang?: string
+    /**
+     * If true, render mode is SSR or pre-rendering (aka SSG). In other words, the
+     * page's HTML will be rendered at build-time or request-time.
+     * If false, render mode is SPA. In other words, the page will only be
+     * rendered in the browser.
+     *
+     * See https://vite-plugin-ssr.com/render-modes
+     *
+     * @default true
+     *
+     */
+    ssr?: boolean
+  }
+}

--- a/vike-react/renderer/types.ts
+++ b/vike-react/renderer/types.ts
@@ -6,11 +6,11 @@ export type { Page }
 export type { Component }
 
 import type {
-  PageContextBuiltIn,
   PageContextBuiltInServer,
-  PageContextBuiltInClientWithClientRouting as PageContextBuiltInClient
+  PageContextBuiltInClientWithClientRouting as PageContextBuiltInClient,
+  Config,
+  ConfigVikeReact
 } from 'vite-plugin-ssr/types'
-import type { Config } from './+config'
 import type { ReactElement } from 'react'
 
 // type Component = (props: Record<string, unknown>) => ReactElement
@@ -29,9 +29,6 @@ export type PageContextCommon = {
   }
 }
 
-type PageContextServer = PageContextBuiltInServer<Page> &
-  PageContextCommon & {
-    config: Config
-  }
+type PageContextServer = PageContextBuiltInServer<Page> & PageContextCommon & { config: Config & ConfigVikeReact }
 type PageContextClient = PageContextBuiltInClient<Page> & PageContextCommon
 type PageContext = PageContextClient | PageContextServer

--- a/vike-react/types.d.ts
+++ b/vike-react/types.d.ts
@@ -3,4 +3,4 @@ export type {
   PageContextBuiltInServer,
   PageContextBuiltInClientWithClientRouting as PageContextBuiltInClient
 } from 'vite-plugin-ssr/types'
-export type { ConfigEnhanced as Config } from './renderer/+config'
+import type { Component } from './renderer/types'


### PR DESCRIPTION
Neat idea by @magne4000 to use [interface merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-interfaces) to enable `vike-*` packages to extend ``import type { Config } from 'vike'`` (currently `import type { Config } from 'vite-plugin-ssr/types'`) without the user needing to do anything.

It uses https://github.com/brillout/vite-plugin-ssr/commit/894c03903265f0fc7ed4d09e8d4c126316b10198 (pre-released as `0.4.140-commit-894c039`).

FYI @AurelienLourot 