### PR TITLE
docs: fix link on NPM

### DIFF
--- a/vike-react/README.md
+++ b/vike-react/README.md
@@ -1,3 +1,5 @@
+<!-- WARNING: keep links absolute in this file so they work on NPM too -->
+
 [<img src="https://avatars.githubusercontent.com/u/86403530?s=200&v=4" align="right" width="64" height="64">](https://vite-plugin-ssr.com)
 [![npm version](https://img.shields.io/npm/v/vike-react)](https://www.npmjs.com/package/vike-react)
 
@@ -7,4 +9,4 @@ React integration for [Vike](https://github.com/brillout/vite-plugin-ssr/issues/
 
 > For integrations with Vue and Solid, see the other [`vike-*` packages](https://vite-plugin-ssr.com/vike-packages).
 
-See [examples/](/examples/).
+See [examples/](https://github.com/vikejs/vike-react/tree/main/examples).


### PR DESCRIPTION
Relative links in README will be dead on NPM.
The README will be published to NPM in the future thanks to https://github.com/vikejs/vike-react/commit/b475e769

FYI @brillout 