### PR TITLE
Allow <ClientOnly /> component to receive props

### DIFF
--- a/packages/vike-react/components/ClientOnly.tsx
+++ b/packages/vike-react/components/ClientOnly.tsx
@@ -7,10 +7,12 @@ function ClientOnly<T>({
   load,
   children,
   fallback,
+  props,
   deps = []
 }: {
   load: () => Promise<{ default: React.ComponentType<T> } | React.ComponentType<T>>
   children: (Component: React.ComponentType<T>) => ReactNode
+  props?: T
   fallback: ReactNode
   deps?: Parameters<typeof useEffect>[1]
 }) {
@@ -38,5 +40,13 @@ function ClientOnly<T>({
     })
   }, deps)
 
-  return Component ? <Component /> : fallback
+  if (!Component) {
+    return fallback
+  }
+
+  if (props) {
+    return <Component {...props} />
+  }
+
+  return <Component />
 }


### PR DESCRIPTION
Hi, first contribution to the project from me!

I'd like to use `<ClientOnly />`, but it probably needs some documentation and I am happy to help with that as well.
This PR is because I believe that `<ClientOnly />` should also receive the props to pass to the lazily loaded component, but I might be misunderstanding the intended usage.
