### PR TITLE
make vike-react-query stream optional

### DIFF
--- a/examples/react-query/pages/+config.h.ts
+++ b/examples/react-query/pages/+config.h.ts
@@ -15,6 +15,7 @@ export default {
   description: 'Demo showcasing Vike + React',
   // <link rel="icon" href="${favicon}" />
   favicon: logoUrl,
+  stream: true,
   extends: [vikeReact, vikeReactQuery],
   passToClient: ['routeParams']
 } satisfies Config

--- a/packages/vike-react-query/renderer/+config.h.ts
+++ b/packages/vike-react-query/renderer/+config.h.ts
@@ -26,7 +26,7 @@ declare global {
     interface ConfigVikeReact {
       queryClientConfig: QueryClientConfig
       FallbackErrorBoundary: (props: { children: ReactNode }) => ReactNode
-      stream: boolean
+      stream?: boolean
     }
   }
 }

--- a/packages/vike-react-query/renderer/+config.h.ts
+++ b/packages/vike-react-query/renderer/+config.h.ts
@@ -5,7 +5,6 @@ export default {
   queryClientConfig: undefined,
   VikeReactQueryWrapper: 'import:vike-react-query/renderer/VikeReactQueryWrapper:default',
   FallbackErrorBoundary: 'import:vike-react-query/renderer/FallbackErrorBoundary:default',
-  stream: true,
   meta: {
     queryClientConfig: {
       env: {
@@ -27,6 +26,7 @@ declare global {
     interface ConfigVikeReact {
       queryClientConfig: QueryClientConfig
       FallbackErrorBoundary: (props: { children: ReactNode }) => ReactNode
+      stream: boolean
     }
   }
 }

--- a/packages/vike-react-query/renderer/VikeReactQueryWrapper.tsx
+++ b/packages/vike-react-query/renderer/VikeReactQueryWrapper.tsx
@@ -9,13 +9,15 @@ type VikeReactQueryWrapperProps = {
 }
 
 export default function VikeReactQueryWrapper({ pageContext, children }: VikeReactQueryWrapperProps) {
-  const { queryClientConfig, FallbackErrorBoundary = PassThrough } = pageContext.config
+  const { queryClientConfig, FallbackErrorBoundary = PassThrough, stream } = pageContext.config
   const [queryClient] = useState(() => new QueryClient(queryClientConfig))
+
+  const RQStreamedHydration = stream ? StreamedHydration : PassThrough
 
   return (
     <QueryClientProvider client={queryClient}>
       <FallbackErrorBoundary>
-        <StreamedHydration client={queryClient}>{children}</StreamedHydration>
+        <RQStreamedHydration>{children}</RQStreamedHydration>
       </FallbackErrorBoundary>
     </QueryClientProvider>
   )


### PR DESCRIPTION
This is just a bit improvement for vike-react-query.
Don't force user to use stream, maybe some users just want to use react query without streaming.