### PR TITLE
qual: use overrides instead of `workspace:*`

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -15,7 +15,7 @@
     "react-dom": "18.2.0",
     "typescript": "^5.3.3",
     "vike": "^0.4.156",
-    "vike-react": "workspace:*",
+    "vike-react": "^0.3.8",
     "vite": "^5.0.11"
   },
   "type": "module"

--- a/examples/onBeforeRender/package.json
+++ b/examples/onBeforeRender/package.json
@@ -15,7 +15,7 @@
     "react-dom": "18.2.0",
     "typescript": "^5.3.3",
     "vike": "^0.4.156",
-    "vike-react": "workspace:*",
+    "vike-react": "^0.3.8",
     "vite": "^5.0.11"
   },
   "type": "module"

--- a/examples/react-query/package.json
+++ b/examples/react-query/package.json
@@ -13,8 +13,8 @@
     "react-dom": "18.2.0",
     "typescript": "^5.3.3",
     "vike": "^0.4.156",
-    "vike-react": "workspace:*",
-    "vike-react-query": "workspace:*",
+    "vike-react": "^0.3.8",
+    "vike-react-query": "^0.0.2",
     "@tanstack/react-query": "^5.17.15",
     "vite": "^5.0.11"
   },

--- a/examples/ssr-spa/package.json
+++ b/examples/ssr-spa/package.json
@@ -13,7 +13,7 @@
     "react-dom": "18.2.0",
     "typescript": "^5.3.3",
     "vike": "^0.4.156",
-    "vike-react": "workspace:*",
+    "vike-react": "^0.3.8",
     "vite": "^5.0.11"
   },
   "type": "module"

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -14,7 +14,7 @@
     "react-streaming": "^0.3.19",
     "typescript": "^5.3.3",
     "vike": "^0.4.156",
-    "vike-react": "workspace:*",
+    "vike-react": "^0.3.8",
     "vite": "^5.0.11"
   },
   "type": "module"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,12 @@
     "========= Only allow pnpm; forbid yarn & npm": "",
     "preinstall": "npx only-allow pnpm"
   },
+  "pnpm": {
+    "overrides": {
+      "vike-react": "link:./packages/vike-react/",
+      "vike-react-query": "link:./packages/vike-react-query/"
+    }
+  },
   "packageManager": "pnpm@8.6.12",
   "devDependencies": {
     "prettier": "^3.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  vike-react: link:./packages/vike-react/
+  vike-react-query: link:./packages/vike-react-query/
+
 importers:
 
   .:
@@ -42,7 +46,7 @@ importers:
         specifier: ^0.4.156
         version: 0.4.156(react-streaming@0.3.19)(vite@5.0.11)
       vike-react:
-        specifier: workspace:*
+        specifier: link:../../packages/vike-react
         version: link:../../packages/vike-react
       vite:
         specifier: ^5.0.11
@@ -78,7 +82,7 @@ importers:
         specifier: ^0.4.156
         version: 0.4.156(react-streaming@0.3.19)(vite@5.0.11)
       vike-react:
-        specifier: workspace:*
+        specifier: link:../../packages/vike-react
         version: link:../../packages/vike-react
       vite:
         specifier: ^5.0.11
@@ -111,10 +115,10 @@ importers:
         specifier: ^0.4.156
         version: 0.4.156(react-streaming@0.3.19)(vite@5.0.11)
       vike-react:
-        specifier: workspace:*
+        specifier: link:../../packages/vike-react
         version: link:../../packages/vike-react
       vike-react-query:
-        specifier: workspace:*
+        specifier: link:../../packages/vike-react-query
         version: link:../../packages/vike-react-query
       vite:
         specifier: ^5.0.11
@@ -144,7 +148,7 @@ importers:
         specifier: ^0.4.156
         version: 0.4.156(react-streaming@0.3.19)(vite@5.0.11)
       vike-react:
-        specifier: workspace:*
+        specifier: link:../../packages/vike-react
         version: link:../../packages/vike-react
       vite:
         specifier: ^5.0.11
@@ -177,7 +181,7 @@ importers:
         specifier: ^0.4.156
         version: 0.4.156(react-streaming@0.3.19)(vite@5.0.11)
       vike-react:
-        specifier: workspace:*
+        specifier: link:../../packages/vike-react
         version: link:../../packages/vike-react
       vite:
         specifier: ^5.0.11
@@ -266,7 +270,7 @@ importers:
         specifier: ^0.4.156
         version: 0.4.156(react-streaming@0.3.19)(vite@4.5.1)
       vike-react:
-        specifier: ^0.3.8
+        specifier: link:../vike-react
         version: link:../vike-react
       vitest:
         specifier: ^1.2.0


### PR DESCRIPTION
This makes the examples easier to copy-paste // #65 
This is already what we do in the vike-vue repository.

FYI @brillout @nitedani @trflagg