### PR TITLE
feat: deprecation warnings for `pageContext.{pageProps,title}`

### DIFF
--- a/packages/vike-react/renderer/getPageElement.tsx
+++ b/packages/vike-react/renderer/getPageElement.tsx
@@ -14,6 +14,9 @@ function getPageElement(pageContext: PageContext): JSX.Element {
   const VikeReactQueryWrapper = pageContext.config.VikeReactQueryWrapper ?? PassThrough
   // TODO/next-major-release: remove pageProps (i.e. tell users to use data() instead of onBeforeRender() to fetch data)
   const { Page, pageProps } = pageContext
+  if (pageProps) {
+    console.warn('[vike-react][warning] pageContext.pageProps is deprecated, use a data() hook instead. See https://vike.dev/useData')
+  }
   const page = (
     <React.StrictMode>
       <PageContextProvider pageContext={pageContext}>

--- a/packages/vike-react/renderer/getTitle.ts
+++ b/packages/vike-react/renderer/getTitle.ts
@@ -16,6 +16,7 @@ function getTitle(pageContext: PageContext): null | string {
   // TODO/next-major-release: remove support for setting title over onBeforeRender()
   // from onBeforeRender() hook
   if (pageContext.title !== undefined) {
+    console.warn('[vike-react][warning] pageContext.title is deprecated, use a data() hook instead. See https://vike.dev/useData')
     return pageContext.title
   }
 


### PR DESCRIPTION
@brillout is it fine if the warnings show up not only on server but also in the browser? Thanks

Also: happy to hold off and adapt according to https://github.com/batijs/bati/pull/166#issuecomment-1902072725