### PR TITLE
fix: use `usePageContext()` for error page of all examples

### DIFF
--- a/examples/basic/pages/_error/+Page.tsx
+++ b/examples/basic/pages/_error/+Page.tsx
@@ -1,14 +1,15 @@
 export default Page
 
 import React from 'react'
+import { usePageContext } from 'vike-react/usePageContext'
 
-function Page({ is404, errorInfo }: { is404: boolean; errorInfo?: string }) {
+function Page() {
+  const { is404 } = usePageContext()
   if (is404) {
     return (
       <>
         <h1>404 Page Not Found</h1>
         <p>This page could not be found.</p>
-        <p>{errorInfo}</p>
       </>
     )
   } else {

--- a/examples/react-query/pages/_error/+Page.tsx
+++ b/examples/react-query/pages/_error/+Page.tsx
@@ -1,14 +1,15 @@
 export default Page
 
 import React from 'react'
+import { usePageContext } from 'vike-react/usePageContext'
 
-function Page({ is404, errorInfo }: { is404: boolean; errorInfo?: string }) {
+function Page() {
+  const { is404 } = usePageContext()
   if (is404) {
     return (
       <>
         <h1>404 Page Not Found</h1>
         <p>This page could not be found.</p>
-        <p>{errorInfo}</p>
       </>
     )
   } else {

--- a/examples/ssr-spa/pages/_error/+Page.tsx
+++ b/examples/ssr-spa/pages/_error/+Page.tsx
@@ -1,14 +1,15 @@
 export default Page
 
 import React from 'react'
+import { usePageContext } from 'vike-react/usePageContext'
 
-function Page({ is404, errorInfo }: { is404: boolean; errorInfo?: string }) {
+function Page() {
+  const { is404 } = usePageContext()
   if (is404) {
     return (
       <>
         <h1>404 Page Not Found</h1>
         <p>This page could not be found.</p>
-        <p>{errorInfo}</p>
       </>
     )
   } else {

--- a/examples/streaming/pages/_error/+Page.tsx
+++ b/examples/streaming/pages/_error/+Page.tsx
@@ -1,14 +1,15 @@
 export default Page
 
 import React from 'react'
+import { usePageContext } from 'vike-react/usePageContext'
 
-function Page({ is404, errorInfo }: { is404: boolean; errorInfo?: string }) {
+function Page() {
+  const { is404 } = usePageContext()
   if (is404) {
     return (
       <>
         <h1>404 Page Not Found</h1>
         <p>This page could not be found.</p>
-        <p>{errorInfo}</p>
       </>
     )
   } else {


### PR DESCRIPTION
Hi Guys, 
AFAIK vike-react doesn't pass any pageContext to any `Page` component anymore, so no more props in the `error Page` too.

cmiiw