### PR TITLE
feat: `onBeforeRenderClient()` (closes #110)

### DIFF
--- a/packages/vike-react/src/+config.ts
+++ b/packages/vike-react/src/+config.ts
@@ -49,6 +49,9 @@ export default {
     _streamIsRequied: {
       env: { server: true }
     },
+    onBeforeRenderClient: {
+      env: { client: true }
+    },
     onAfterRenderClient: {
       env: { client: true }
     },

--- a/packages/vike-react/src/renderer/onRenderClient.tsx
+++ b/packages/vike-react/src/renderer/onRenderClient.tsx
@@ -17,6 +17,7 @@ const onRenderClient: OnRenderClientSync = (pageContext): ReturnType<OnRenderCli
 
   const container = document.getElementById('react-root')!
   if (container.innerHTML !== '' && pageContext.isHydration) {
+    pageContext.config.onBeforeRenderClient?.(pageContext)
     // First render (hydration)
     root = ReactDOM.hydrateRoot(container, page, {
       // @ts-expect-error

--- a/packages/vike-react/src/renderer/onRenderClient.tsx
+++ b/packages/vike-react/src/renderer/onRenderClient.tsx
@@ -8,6 +8,8 @@ import { getPageElement } from './getPageElement.js'
 
 let root: ReactDOM.Root
 const onRenderClient: OnRenderClientSync = (pageContext): ReturnType<OnRenderClientSync> => {
+  pageContext.config.onBeforeRenderClient?.(pageContext)
+
   const page = getPageElement(pageContext)
 
   // TODO: implement this? So that, upon errors, onRenderClient() throws an error and Vike can render the error. As of April 2024 it isn't released yet.
@@ -17,7 +19,6 @@ const onRenderClient: OnRenderClientSync = (pageContext): ReturnType<OnRenderCli
 
   const container = document.getElementById('react-root')!
   if (container.innerHTML !== '' && pageContext.isHydration) {
-    pageContext.config.onBeforeRenderClient?.(pageContext)
     // First render (hydration)
     root = ReactDOM.hydrateRoot(container, page, {
       // @ts-expect-error

--- a/packages/vike-react/src/types/Config.ts
+++ b/packages/vike-react/src/types/Config.ts
@@ -59,6 +59,13 @@ declare global {
        */
       stream?: boolean
       /**
+       * Client-side hook called before the page is rendered.
+       */
+
+      // https://github.com/vikejs/vike-react/issues/999
+      onBeforeRenderClient?: (pageContext: PageContextClient) => void
+
+      /**
        * Client-side hook called after the page is rendered.
        */
 

--- a/packages/vike-react/src/types/Config.ts
+++ b/packages/vike-react/src/types/Config.ts
@@ -62,7 +62,7 @@ declare global {
        * Client-side hook called before the page is rendered.
        */
 
-      // https://github.com/vikejs/vike-react/issues/999
+      // https://github.com/vikejs/vike-react/issues/110
       onBeforeRenderClient?: (pageContext: PageContextClient) => void
 
       /**


### PR DESCRIPTION
This PR adds a custom hook `onBeforeRenderClient`, enabling custom logic to run before the render pass on the client side.

This addresses #110 and works the same as #96 

It also includes a minimal example with async data fetching on the server side and store hydration on the client pass.

An additional change includes adding `rimraf` package to allow building on a Windows environment w/o having to resort to WSL or 3rd party CLI tools.

