### PR TITLE
fix: make `<Wrapper>` cumulative

### DIFF
--- a/packages/vike-react-query/package.json
+++ b/packages/vike-react-query/package.json
@@ -7,7 +7,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./config": "./dist/renderer/+config.js",
-    "./renderer/VikeReactQueryWrapper": "./dist/renderer/VikeReactQueryWrapper.js",
+    "./renderer/Wrapper": "./dist/renderer/Wrapper.js",
     "./renderer/FallbackErrorBoundary": "./dist/renderer/FallbackErrorBoundary.js"
   },
   "scripts": {
@@ -53,8 +53,8 @@
       "config": [
         "dist/renderer/+config.d.ts"
       ],
-      "renderer/VikeReactQueryWrapper": [
-        "dist/renderer/VikeReactQueryWrapper.d.ts"
+      "renderer/Wrapper": [
+        "dist/renderer/Wrapper.d.ts"
       ]
     }
   },

--- a/packages/vike-react-query/renderer/+config.ts
+++ b/packages/vike-react-query/renderer/+config.ts
@@ -9,7 +9,7 @@ export default {
     'vike-react': '>=0.4.12'
   },
   queryClientConfig: undefined,
-  VikeReactQueryWrapper: 'import:vike-react-query/renderer/VikeReactQueryWrapper:default',
+  Wrapper: 'import:vike-react-query/renderer/Wrapper:default',
   FallbackErrorBoundary: 'import:vike-react-query/renderer/FallbackErrorBoundary:default',
   streamIsRequired: true,
   meta: {

--- a/packages/vike-react-query/renderer/Wrapper.tsx
+++ b/packages/vike-react-query/renderer/Wrapper.tsx
@@ -3,12 +3,12 @@ import React, { ReactNode, useState } from 'react'
 import type { PageContext } from 'vike/types'
 import { StreamedHydration } from './StreamedHydration.js'
 
-type VikeReactQueryWrapperProps = {
+type WrapperProps = {
   pageContext: PageContext
   children: ReactNode
 }
 
-export default function VikeReactQueryWrapper({ pageContext, children }: VikeReactQueryWrapperProps) {
+export default function Wrapper({ pageContext, children }: WrapperProps) {
   const { queryClientConfig, FallbackErrorBoundary = PassThrough } = pageContext.config
   const [queryClient] = useState(() => new QueryClient(queryClientConfig))
 

--- a/packages/vike-react-query/renderer/Wrapper.tsx
+++ b/packages/vike-react-query/renderer/Wrapper.tsx
@@ -1,14 +1,10 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React, { ReactNode, useState } from 'react'
-import type { PageContext } from 'vike/types'
 import { StreamedHydration } from './StreamedHydration.js'
+import { usePageContext } from 'vike-react/usePageContext'
 
-type WrapperProps = {
-  pageContext: PageContext
-  children: ReactNode
-}
-
-export default function Wrapper({ pageContext, children }: WrapperProps) {
+export default function Wrapper({ children }: { children: ReactNode }) {
+  const pageContext = usePageContext()
   const { queryClientConfig, FallbackErrorBoundary = PassThrough } = pageContext.config
   const [queryClient] = useState(() => new QueryClient(queryClientConfig))
 

--- a/packages/vike-react/src/+config.ts
+++ b/packages/vike-react/src/+config.ts
@@ -58,7 +58,7 @@ export default {
     onAfterRenderClient: {
       env: { client: true }
     },
-    VikeReactQueryWrapper: {
+    Wrapper: {
       env: { client: true, server: true }
     },
     Wrapper: {

--- a/packages/vike-react/src/+config.ts
+++ b/packages/vike-react/src/+config.ts
@@ -59,9 +59,7 @@ export default {
       env: { client: true }
     },
     Wrapper: {
-      env: { client: true, server: true }
-    },
-    Wrapper: {
+      cumulative: true,
       env: { client: true, server: true }
     },
     // Vike already defines the setting 'name', but we redundantly define it here for older Vike versions (otherwise older Vike versions will complain that 'name` is an unknown config). TODO/eventually: remove this once <=0.4.172 versions become rare (also because we use the `require` setting starting from `0.4.173`).

--- a/packages/vike-react/src/renderer/getPageElement.tsx
+++ b/packages/vike-react/src/renderer/getPageElement.tsx
@@ -7,15 +7,15 @@ import { PageContextProvider } from '../hooks/usePageContext.js'
 function getPageElement(pageContext: PageContext): JSX.Element {
   const Layout = pageContext.config.Layout ?? PassThrough
   const Wrapper = pageContext.config.Wrapper ?? PassThrough
-  const VikeReactQueryWrapper = pageContext.config.VikeReactQueryWrapper ?? (PassThrough as any)
+  const Wrapper = pageContext.config.Wrapper ?? (PassThrough as any)
   const { Page } = pageContext
   let page = (
     <PageContextProvider pageContext={pageContext}>
-      <VikeReactQueryWrapper pageContext={pageContext}>
+      <Wrapper pageContext={pageContext}>
         <Wrapper>
           <Layout>{Page ? <Page /> : null}</Layout>
         </Wrapper>
-      </VikeReactQueryWrapper>
+      </Wrapper>
     </PageContextProvider>
   )
   if (pageContext.config.reactStrictMode !== false) {

--- a/packages/vike-react/src/renderer/getPageElement.tsx
+++ b/packages/vike-react/src/renderer/getPageElement.tsx
@@ -5,22 +5,20 @@ import type { PageContext } from 'vike/types'
 import { PageContextProvider } from '../hooks/usePageContext.js'
 
 function getPageElement(pageContext: PageContext): JSX.Element {
+  // Main component
   const Layout = pageContext.config.Layout ?? PassThrough
-  const Wrapper = pageContext.config.Wrapper ?? PassThrough
-  const Wrapper = pageContext.config.Wrapper ?? (PassThrough as any)
   const { Page } = pageContext
-  let page = (
-    <PageContextProvider pageContext={pageContext}>
-      <Wrapper pageContext={pageContext}>
-        <Wrapper>
-          <Layout>{Page ? <Page /> : null}</Layout>
-        </Wrapper>
-      </Wrapper>
-    </PageContextProvider>
-  )
+  let page = <Layout>{Page ? <Page /> : null}</Layout>
+
+  // Wrapper components
+  ;(pageContext.config.Wrapper || []).forEach((Wrapper) => {
+    page = <Wrapper>{page}</Wrapper>
+  })
+  page = <PageContextProvider pageContext={pageContext}>{page}</PageContextProvider>
   if (pageContext.config.reactStrictMode !== false) {
     page = <React.StrictMode>{page}</React.StrictMode>
   }
+
   return page
 }
 

--- a/packages/vike-react/src/types/Config.ts
+++ b/packages/vike-react/src/types/Config.ts
@@ -1,5 +1,5 @@
 // https://vike.dev/meta#typescript
-import type { PageContextClient } from 'vike/types'
+import type { ImportString, PageContextClient } from 'vike/types'
 
 declare global {
   namespace Vike {
@@ -24,7 +24,7 @@ declare global {
        *
        * https://vike.dev/Wrapper
        */
-      Wrapper?: (props: { children: React.ReactNode }) => React.ReactNode
+      Wrapper?: Wrapper | ImportString
 
       /** &lt;title>${title}&lt;/title> */
       title?: string
@@ -90,9 +90,11 @@ declare global {
        * https://vike.dev/onAfterRenderClient
        */
       onAfterRenderClient?: (pageContext: PageContextClient) => void
-
-      // Temporary until Wrapper is cumulative
-      Wrapper?: React.ReactNode
+    }
+    interface ConfigResolved {
+      Wrapper?: Wrapper[]
     }
   }
 }
+
+type Wrapper = (props: { children: React.ReactNode }) => React.ReactNode

--- a/packages/vike-react/src/types/Config.ts
+++ b/packages/vike-react/src/types/Config.ts
@@ -92,7 +92,7 @@ declare global {
       onAfterRenderClient?: (pageContext: PageContextClient) => void
 
       // Temporary until Wrapper is cumulative
-      VikeReactQueryWrapper?: React.ReactNode
+      Wrapper?: React.ReactNode
     }
   }
 }


### PR DESCRIPTION
FYI @nitedani Vike now supports cumulative non-serializable configs (e.g. hooks and components).