### PR TITLE
fix: export getHeadHtml getPageHtml from vike-react

### DIFF
--- a/packages/vike-react/src/renderer/onRenderHtml.tsx
+++ b/packages/vike-react/src/renderer/onRenderHtml.tsx
@@ -1,5 +1,5 @@
 // https://vike.dev/onRenderHtml
-export { onRenderHtml }
+export { getHeadHtml, getPageHtml, onRenderHtml }
 
 import React from 'react'
 import { renderToString } from 'react-dom/server'


### PR DESCRIPTION
In the event someone wants to create their own `onRenderHtml` HTML output, but still wants to take advantage of the other features `vike-react` provides, we should export `getHeadHtml` and `getPageHtml`.

Although, maybe the best way to do this is to have yet another hook which returns the HTML.