### PR TITLE
feat: add bodyHtmlBegin, bodyHtmlEnd

### DIFF
--- a/packages/vike-react/src/+config.ts
+++ b/packages/vike-react/src/+config.ts
@@ -56,6 +56,16 @@ const config = {
     lang: {
       env: { server: true, client: true },
     },
+    bodyHtmlBegin: {
+      env: { server: true },
+      cumulative: true,
+      global: true,
+    },
+    bodyHtmlEnd: {
+      env: { server: true },
+      cumulative: true,
+      global: true,
+    },
     htmlAttributes: {
       env: { server: true },
       global: true,

--- a/packages/vike-react/src/integration/onRenderHtml.tsx
+++ b/packages/vike-react/src/integration/onRenderHtml.tsx
@@ -24,12 +24,12 @@ const onRenderHtml: OnRenderHtmlAsync = async (
 
   const headHtml = getHeadHtml(pageContext)
 
+  const { bodyHtmlBegin, bodyHtmlEnd } = await getBodyHtmlBoundary(pageContext)
+
   const { htmlAttributesString, bodyAttributesString } = getTagAttributes(pageContext)
 
   // Not needed on the client-side, thus we remove it to save KBs sent to the client
   delete pageContext._configFromHook
-
-  const { bodyHtmlBegin, bodyHtmlEnd } = await getBodyHtmlBeginEnd(pageContext)
 
   return escapeInject`<!DOCTYPE html>
     <html${dangerouslySkipEscape(htmlAttributesString)}>
@@ -181,13 +181,12 @@ function addEcosystemStamp() {
     {}
 }
 
-async function getBodyHtmlBeginEnd(pageContext: PageContextServer) {
+async function getBodyHtmlBoundary(pageContext: PageContextServer) {
   const bodyHtmlBegin = dangerouslySkipEscape(
     (await callCumulativeHooks(pageContext.config.bodyHtmlBegin, pageContext)).join(''),
   )
-
-  const bodyHtmlEndHooks = [...(pageContext.config.bodyHtmlEnd ?? [])]
-  const bodyHtmlEnd = dangerouslySkipEscape((await callCumulativeHooks(bodyHtmlEndHooks, pageContext)).join(''))
-
+  const bodyHtmlEnd = dangerouslySkipEscape(
+    (await callCumulativeHooks(pageContext.config.bodyHtmlEnd, pageContext)).join(''),
+  )
   return { bodyHtmlBegin, bodyHtmlEnd }
 }

--- a/packages/vike-react/src/integration/onRenderHtml.tsx
+++ b/packages/vike-react/src/integration/onRenderHtml.tsx
@@ -29,6 +29,8 @@ const onRenderHtml: OnRenderHtmlAsync = async (
   // Not needed on the client-side, thus we remove it to save KBs sent to the client
   delete pageContext._configFromHook
 
+  const { bodyHtmlBegin, bodyHtmlEnd } = await getBodyHtmlBeginEnd(pageContext)
+
   return escapeInject`<!DOCTYPE html>
     <html${dangerouslySkipEscape(htmlAttributesString)}>
       <head>
@@ -36,7 +38,9 @@ const onRenderHtml: OnRenderHtmlAsync = async (
         ${headHtml}
       </head>
       <body${dangerouslySkipEscape(bodyAttributesString)}>
+        ${bodyHtmlBegin}
         <div id="root">${pageHtml}</div>
+        ${bodyHtmlEnd}
       </body>
     </html>`
 }
@@ -175,4 +179,15 @@ function addEcosystemStamp() {
     */
     // We use an object so that we can eventually, in the future, add helpful information as needed. (E.g. the vike-react version.)
     {}
+}
+
+async function getBodyHtmlBeginEnd(pageContext: PageContextServer) {
+  const bodyHtmlBegin = dangerouslySkipEscape(
+    (await callCumulativeHooks(pageContext.config.bodyHtmlBegin, pageContext)).join(''),
+  )
+
+  const bodyHtmlEndHooks = [...(pageContext.config.bodyHtmlEnd ?? [])]
+  const bodyHtmlEnd = dangerouslySkipEscape((await callCumulativeHooks(bodyHtmlEndHooks, pageContext)).join(''))
+
+  return { bodyHtmlBegin, bodyHtmlEnd }
 }

--- a/packages/vike-react/src/types/Config.ts
+++ b/packages/vike-react/src/types/Config.ts
@@ -115,16 +115,14 @@ declare global {
       lang?: string | null | ((pageContext: PageContext_) => string | null | undefined)
 
       /**
-       * The result of this is injected at the start of `<body>`.
+       * Raw HTML injected at the start of `<body>`.
        *
        * https://vike.dev/bodyHtmlBegin
        */
       bodyHtmlBegin?: BodyInjectHtml
 
       /**
-       * The result of this is injected at the end of `<body>`.
-       *
-       * @default `<div id="teleported"></div>`
+       * Raw HTML injected at the end of `<body>`.
        *
        * https://vike.dev/bodyHtmlEnd
        */

--- a/packages/vike-react/src/types/Config.ts
+++ b/packages/vike-react/src/types/Config.ts
@@ -119,14 +119,14 @@ declare global {
        *
        * https://vike.dev/bodyHtmlBegin
        */
-      bodyHtmlBegin?: BodyInjectHtml
+      bodyHtmlBegin?: BodyHtmlBoundary
 
       /**
        * Raw HTML injected at the end of `<body>`.
        *
        * https://vike.dev/bodyHtmlEnd
        */
-      bodyHtmlEnd?: BodyInjectHtml
+      bodyHtmlEnd?: BodyHtmlBoundary
 
       /**
        * Add tag attributes such as `<html class="dark">`.
@@ -216,8 +216,8 @@ declare global {
       Wrapper?: Wrapper[]
       Layout?: Layout[]
       Head?: Head[]
-      bodyHtmlBegin?: BodyInjectHtml[]
-      bodyHtmlEnd?: BodyInjectHtml[]
+      bodyHtmlBegin?: BodyHtmlBoundary[]
+      bodyHtmlEnd?: BodyHtmlBoundary[]
       bodyAttributes?: TagAttributes[]
       htmlAttributes?: TagAttributes[]
       onAfterRenderHtml?: Function[]
@@ -232,7 +232,7 @@ declare global {
 // - https://github.com/Microsoft/TypeScript/issues/983
 type PageContext_ = PageContext
 
-type BodyInjectHtml = string | ((pageContext: PageContext) => string)
+type BodyHtmlBoundary = string | ((pageContext: PageContext) => string)
 
 export type Head = React.ReactNode | (() => React.ReactNode)
 type Wrapper = (props: { children: React.ReactNode }) => React.ReactNode

--- a/packages/vike-react/src/types/Config.ts
+++ b/packages/vike-react/src/types/Config.ts
@@ -115,6 +115,22 @@ declare global {
       lang?: string | null | ((pageContext: PageContext_) => string | null | undefined)
 
       /**
+       * The result of this is injected at the start of `<body>`.
+       *
+       * https://vike.dev/bodyHtmlBegin
+       */
+      bodyHtmlBegin?: BodyInjectHtml
+
+      /**
+       * The result of this is injected at the end of `<body>`.
+       *
+       * @default `<div id="teleported"></div>`
+       *
+       * https://vike.dev/bodyHtmlEnd
+       */
+      bodyHtmlEnd?: BodyInjectHtml
+
+      /**
        * Add tag attributes such as `<html class="dark">`.
        *
        * https://vike.dev/htmlAttributes
@@ -202,6 +218,8 @@ declare global {
       Wrapper?: Wrapper[]
       Layout?: Layout[]
       Head?: Head[]
+      bodyHtmlBegin?: BodyInjectHtml[]
+      bodyHtmlEnd?: BodyInjectHtml[]
       bodyAttributes?: TagAttributes[]
       htmlAttributes?: TagAttributes[]
       onAfterRenderHtml?: Function[]
@@ -215,6 +233,8 @@ declare global {
 // - https://stackoverflow.com/questions/46559021/typescript-use-of-global-type-inside-namespace-with-same-type
 // - https://github.com/Microsoft/TypeScript/issues/983
 type PageContext_ = PageContext
+
+type BodyInjectHtml = string | ((pageContext: PageContext) => string)
 
 export type Head = React.ReactNode | (() => React.ReactNode)
 type Wrapper = (props: { children: React.ReactNode }) => React.ReactNode


### PR DESCRIPTION
Ported from `vike-vue`, adds the `bodyHtmlBegin` and `bodyHtmlEnd` config options to inject HTML into `<body>`