### PR TITLE
fix: fix infinite requests for useSuspenseQuery

### DIFF
--- a/packages/vike-react-query/integration/Wrapper.tsx
+++ b/packages/vike-react-query/integration/Wrapper.tsx
@@ -1,6 +1,6 @@
 export { Wrapper }
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient, QueryClientConfig, QueryClientProvider } from '@tanstack/react-query'
 import React, { ReactNode, useState } from 'react'
 import { StreamedHydration } from './StreamedHydration.js'
 import { usePageContext } from 'vike-react/usePageContext'
@@ -9,8 +9,12 @@ function Wrapper({ children }: { children: ReactNode }) {
   const pageContext = usePageContext()
   const { queryClientConfig, FallbackErrorBoundary = PassThrough } = pageContext.config
   const [queryClient] = useState(() => {
-    const config = typeof queryClientConfig === 'function' ? queryClientConfig(pageContext) : queryClientConfig
-    return new QueryClient(config)
+    const options = typeof queryClientConfig === 'function' ? queryClientConfig(pageContext) : queryClientConfig
+    // React may throw away a partially rendered tree if it suspends, and then start again from scratch.
+    // If it's no suspense boundary between the creation of queryClient and useSuspenseQuery,
+    // then the entire tree is thrown away, including the creation of queryClient, which may produce infinity refetchs
+    // https://github.com/TanStack/query/issues/6116#issuecomment-1904051005
+    return getQueryClient(options)
   })
 
   return (
@@ -24,4 +28,25 @@ function Wrapper({ children }: { children: ReactNode }) {
 
 function PassThrough({ children }: any) {
   return <>{children}</>
+}
+
+function makeQueryClient(config: QueryClientConfig | undefined) {
+  return new QueryClient(config)
+}
+
+let clientQueryClient: QueryClient | undefined = undefined
+
+function getQueryClient(config: QueryClientConfig | undefined) {
+  if (isBrowser()) {
+    if (!clientQueryClient) clientQueryClient = makeQueryClient(config)
+    return clientQueryClient
+  } else {
+    return makeQueryClient(config)
+  }
+}
+
+function isBrowser() {
+  // Using `typeof window !== 'undefined'` alone is not enough because some users use https://www.npmjs.com/package/ssr-window
+  return typeof window !== 'undefined' && typeof window.scrollY === 'number'
+  // Alternatively, test whether environment is a *real* browser: https://github.com/brillout/picocolors/blob/d59a33a0fd52a8a33e4158884069192a89ce0113/picocolors.js#L87-L89
 }


### PR DESCRIPTION
Faced the same bug as https://github.com/TanStack/query/issues/6116. A page requests data from `useSuspense` hook in an infinite loop and then fails. 

Took the solution from the [comment](https://github.com/TanStack/query/issues/6116#issuecomment-1904051005) with bug explanation.

![image](https://github.com/user-attachments/assets/5130f089-ee20-42e5-b3b9-e3c95c74e10a)
