### PR TITLE
 fix(security): patch devalue and vite vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 .pnpm-debug.log
+.idea

--- a/examples/apollo/package.json
+++ b/examples/apollo/package.json
@@ -5,19 +5,19 @@
     "preview": "vike build && vike preview"
   },
   "dependencies": {
+    "@apollo/client": "^3.10.8",
+    "@apollo/client-react-streaming": "^0.11.2",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.3",
+    "graphql": "^16.9.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "typescript": "^5.9.2",
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
     "vike-react-apollo": "0.1.6",
-    "@apollo/client": "^3.10.8",
-    "@apollo/client-react-streaming": "^0.11.2",
-    "graphql": "^16.9.0",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "type": "module"
 }

--- a/examples/full/package.json
+++ b/examples/full/package.json
@@ -14,7 +14,7 @@
     "typescript": "^5.9.3",
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "type": "module"
 }

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -10,7 +10,7 @@
     "react-dom": "^19.2.1",
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "type": "module"
 }

--- a/examples/query/package.json
+++ b/examples/query/package.json
@@ -4,6 +4,7 @@
     "preview": "vike build && vike preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.20.1",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.3",
@@ -13,8 +14,7 @@
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
     "vike-react-query": "0.1.12",
-    "@tanstack/react-query": "^5.20.1",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "type": "module"
 }

--- a/examples/redux/package.json
+++ b/examples/redux/package.json
@@ -17,7 +17,7 @@
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
     "vike-react-redux": "0.1.3",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "type": "module"
 }

--- a/examples/sentry/package.json
+++ b/examples/sentry/package.json
@@ -5,8 +5,8 @@
     "prod": "vike build && node ./dist/server/index.mjs"
   },
   "dependencies": {
-    "@sentry/react": "^10.22.0",
     "@sentry/node": "^10.22.0",
+    "@sentry/react": "^10.22.0",
     "@sentry/vite-plugin": "^4.6.0",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
@@ -18,7 +18,7 @@
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
     "vike-react-sentry": "0.1.0",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "type": "module"
 }

--- a/examples/zustand/package.json
+++ b/examples/zustand/package.json
@@ -16,7 +16,7 @@
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
     "vike-react-zustand": "0.1.9",
-    "vite": "^7.3.0",
+    "vite": "^7.3.5",
     "zustand": "^5.0.8"
   },
   "type": "module"

--- a/packages/vike-react-antd/package.json
+++ b/packages/vike-react-antd/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.9.2",
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "typesVersions": {
     "*": {

--- a/packages/vike-react-apollo/package.json
+++ b/packages/vike-react-apollo/package.json
@@ -19,29 +19,29 @@
   },
   "peerDependencies": {
     "@apollo/client": ">=3.0.0",
-    "graphql": ">=16.0.0",
     "@apollo/client-react-streaming": ">=0.11.0",
+    "graphql": ">=16.0.0",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0",
     "react-streaming": ">=0.3.41",
     "vike-react": ">=0.6.4"
   },
   "devDependencies": {
-    "@brillout/release-me": "^0.4.13",
     "@apollo/client": "^3.10.8",
     "@apollo/client-react-streaming": "^0.11.2",
-    "graphql": "^16.9.0",
+    "@brillout/release-me": "^0.4.13",
     "@types/node": "^24.0.8",
     "@types/react": "^19.1.13",
+    "@types/react-dom": "^19.1.9",
+    "graphql": "^16.9.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
-    "@types/react-dom": "^19.1.9",
     "react-streaming": "^0.4.16",
     "rimraf": "^5.0.5",
     "typescript": "^5.9.2",
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "dependencies": {
     "react-error-boundary": "^4.0.12"

--- a/packages/vike-react-chakra/package.json
+++ b/packages/vike-react-chakra/package.json
@@ -31,7 +31,7 @@
     "typescript": "^5.9.2",
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "typesVersions": {
     "*": {

--- a/packages/vike-react-query/package.json
+++ b/packages/vike-react-query/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.9.2",
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
-    "vite": "^7.3.0",
+    "vite": "^7.3.5",
     "vitest": "^3.2.4"
   },
   "dependencies": {

--- a/packages/vike-react-query/package.json
+++ b/packages/vike-react-query/package.json
@@ -45,7 +45,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "devalue": "^4.3.2",
+    "devalue": "^5.6.4",
     "react-error-boundary": "^4.0.12"
   },
   "typesVersions": {

--- a/packages/vike-react-redux/package.json
+++ b/packages/vike-react-redux/package.json
@@ -34,7 +34,7 @@
     "typescript": "^5.9.2",
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "typesVersions": {
     "*": {

--- a/packages/vike-react-sentry/package.json
+++ b/packages/vike-react-sentry/package.json
@@ -6,8 +6,8 @@
     "@brillout/vite-plugin-server-entry": "^0.7.0"
   },
   "peerDependencies": {
-    "@sentry/react": ">=10.0.0",
     "@sentry/node": ">=10.0.0",
+    "@sentry/react": ">=10.0.0",
     "@sentry/vite-plugin": ">=4.0.0",
     "react": ">=18.0.0",
     "vike-react": ">=0.6.4"
@@ -33,8 +33,8 @@
   "devDependencies": {
     "@brillout/release-me": "^0.4.13",
     "@brillout/vite-plugin-server-entry": "^0.7.15",
-    "@sentry/react": "^10.22.0",
     "@sentry/node": "^10.22.0",
+    "@sentry/react": "^10.22.0",
     "@sentry/vite-plugin": "^4.6.0",
     "@types/node": "^24.0.8",
     "@types/react": "^19.1.13",
@@ -43,7 +43,7 @@
     "typescript": "^5.9.2",
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "typesVersions": {
     "*": {

--- a/packages/vike-react-styled-components/package.json
+++ b/packages/vike-react-styled-components/package.json
@@ -18,8 +18,8 @@
     "release:commit": "release-me commit"
   },
   "peerDependencies": {
-    "styled-components": ">=6",
     "react": ">=18",
+    "styled-components": ">=6",
     "vike-react": ">=0.4.13"
   },
   "devDependencies": {
@@ -31,7 +31,7 @@
     "typescript": "^5.9.2",
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "typesVersions": {
     "*": {

--- a/packages/vike-react-styled-jsx/package.json
+++ b/packages/vike-react-styled-jsx/package.json
@@ -18,8 +18,8 @@
     "release:commit": "release-me commit"
   },
   "peerDependencies": {
-    "styled-jsx": ">=5",
     "react": ">=18",
+    "styled-jsx": ">=5",
     "vike-react": ">=0.4.13"
   },
   "devDependencies": {
@@ -32,7 +32,7 @@
     "typescript": "^5.9.2",
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "typesVersions": {
     "*": {

--- a/packages/vike-react-zustand/package.json
+++ b/packages/vike-react-zustand/package.json
@@ -32,12 +32,12 @@
     "@types/react-dom": "^19.1.9",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
+    "react-streaming": "^0.4.16",
     "rimraf": "^5.0.5",
     "typescript": "^5.9.2",
     "vike": "^0.4.259",
     "vike-react": "0.6.23",
-    "react-streaming": "^0.4.16",
-    "vite": "^7.3.0",
+    "vite": "^7.3.5",
     "zustand": "^5.0.3"
   },
   "dependencies": {

--- a/packages/vike-react/package.json
+++ b/packages/vike-react/package.json
@@ -56,7 +56,7 @@
     "rimraf": "^5.0.5",
     "typescript": "^5.9.2",
     "vike": "^0.4.259",
-    "vite": "^7.3.0"
+    "vite": "^7.3.5"
   },
   "typesVersions": {
     "*": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,8 +440,8 @@ importers:
   packages/vike-react-query:
     dependencies:
       devalue:
-        specifier: ^4.3.2
-        version: 4.3.3
+        specifier: ^5.6.4
+        version: 5.8.1
       react-error-boundary:
         specifier: ^4.0.12
         version: 4.1.2(react@19.2.1)
@@ -2578,8 +2578,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  devalue@4.3.3:
-    resolution: {integrity: sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -6284,7 +6284,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  devalue@4.3.3: {}
+  devalue@5.8.1: {}
 
   dom-accessibility-api@0.5.16: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react':
         specifier: ^5.0.3
-        version: 5.1.1(vite@7.3.0(@types/node@24.0.8))
+        version: 5.1.1(vite@7.3.5(@types/node@24.0.8))
       graphql:
         specifier: ^16.9.0
         version: 16.10.0
@@ -55,7 +55,7 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../../packages/vike-react
@@ -63,8 +63,8 @@ importers:
         specifier: 0.1.6
         version: link:../../packages/vike-react-apollo
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   examples/full:
     dependencies:
@@ -76,7 +76,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react':
         specifier: ^5.1.1
-        version: 5.1.1(vite@7.3.0(@types/node@24.0.8))
+        version: 5.1.1(vite@7.3.5(@types/node@24.0.8))
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -91,19 +91,19 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../../packages/vike-react
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   examples/minimal:
     dependencies:
       '@vitejs/plugin-react':
         specifier: ^5.0.3
-        version: 5.1.1(vite@7.3.0(@types/node@24.0.8))
+        version: 5.1.1(vite@7.3.5(@types/node@24.0.8))
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -112,13 +112,13 @@ importers:
         version: 19.2.1(react@19.2.1)
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../../packages/vike-react
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   examples/query:
     dependencies:
@@ -133,7 +133,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react':
         specifier: ^5.0.3
-        version: 5.1.1(vite@7.3.0(@types/node@24.0.8))
+        version: 5.1.1(vite@7.3.5(@types/node@24.0.8))
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -145,7 +145,7 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../../packages/vike-react
@@ -153,14 +153,14 @@ importers:
         specifier: 0.1.12
         version: link:../../packages/vike-react-query
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   examples/redux:
     dependencies:
       '@reduxjs/toolkit':
         specifier: ^2.8.2
-        version: 2.8.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@5.0.1))(react@19.2.1)
+        version: 2.8.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)
       '@types/react':
         specifier: ^19.1.13
         version: 19.2.7
@@ -169,7 +169,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react':
         specifier: ^5.0.3
-        version: 5.1.1(vite@7.3.0(@types/node@24.0.8))
+        version: 5.1.1(vite@7.3.5(@types/node@24.0.8))
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -184,7 +184,7 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../../packages/vike-react
@@ -192,8 +192,8 @@ importers:
         specifier: 0.1.3
         version: link:../../packages/vike-react-redux
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   examples/sentry:
     dependencies:
@@ -214,7 +214,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react':
         specifier: ^5.0.3
-        version: 5.1.1(vite@7.3.0(@types/node@24.0.8))
+        version: 5.1.1(vite@7.3.5(@types/node@24.0.8))
       hono:
         specifier: ^4.12.14
         version: 4.12.14
@@ -229,7 +229,7 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../../packages/vike-react
@@ -237,8 +237,8 @@ importers:
         specifier: 0.1.0
         version: link:../../packages/vike-react-sentry
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   examples/zustand:
     dependencies:
@@ -250,7 +250,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react':
         specifier: ^5.0.4
-        version: 5.1.1(vite@7.3.0(@types/node@24.0.8))
+        version: 5.1.1(vite@7.3.5(@types/node@24.0.8))
       immer:
         specifier: ^10.1.3
         version: 10.1.3
@@ -265,7 +265,7 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../../packages/vike-react
@@ -273,8 +273,8 @@ importers:
         specifier: 0.1.9
         version: link:../../packages/vike-react-zustand
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
       zustand:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.7)(immer@10.1.3)(react@19.2.1)(use-sync-external-store@1.4.0(react@19.2.1))
@@ -314,10 +314,10 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   packages/vike-react-antd:
     devDependencies:
@@ -344,13 +344,13 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../vike-react
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   packages/vike-react-apollo:
     dependencies:
@@ -396,13 +396,13 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../vike-react
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   packages/vike-react-chakra:
     devDependencies:
@@ -429,13 +429,13 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../vike-react
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   packages/vike-react-query:
     dependencies:
@@ -484,13 +484,13 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../vike-react
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.0.8)(jsdom@24.1.3)
@@ -506,7 +506,7 @@ importers:
         version: 0.4.13(conventional-commits-filter@5.0.0)
       '@reduxjs/toolkit':
         specifier: ^2.8.2
-        version: 2.8.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@5.0.1))(react@19.2.1)
+        version: 2.8.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)
       '@types/react':
         specifier: ^19.1.13
         version: 19.2.7
@@ -524,13 +524,13 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../vike-react
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   packages/vike-react-sentry:
     dependencies:
@@ -567,13 +567,13 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../vike-react
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   packages/vike-react-styled-components:
     devDependencies:
@@ -597,13 +597,13 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../vike-react
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   packages/vike-react-styled-jsx:
     devDependencies:
@@ -630,13 +630,13 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../vike-react
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
 
   packages/vike-react-zustand:
     dependencies:
@@ -682,13 +682,13 @@ importers:
         version: 5.9.3
       vike:
         specifier: ^0.4.259
-        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+        version: 0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       vike-react:
         specifier: 0.6.23
         version: link:../vike-react
       vite:
-        specifier: ^7.3.0
-        version: 7.3.0(@types/node@24.0.8)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.0.8)
       zustand:
         specifier: ^5.0.3
         version: 5.0.8(@types/react@19.2.7)(immer@10.1.3)(react@19.2.1)(use-sync-external-store@1.4.0(react@19.2.1))
@@ -1060,6 +1060,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.23.1':
     resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
     engines: {node: '>=18'}
@@ -1068,6 +1074,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1084,6 +1096,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.23.1':
     resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
     engines: {node: '>=18'}
@@ -1092,6 +1110,12 @@ packages:
 
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1108,6 +1132,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.23.1':
     resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
     engines: {node: '>=18'}
@@ -1116,6 +1146,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.2':
     resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1132,6 +1168,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.23.1':
     resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
     engines: {node: '>=18'}
@@ -1140,6 +1182,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.2':
     resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1156,6 +1204,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.23.1':
     resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
     engines: {node: '>=18'}
@@ -1164,6 +1218,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.2':
     resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1180,6 +1240,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.23.1':
     resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
     engines: {node: '>=18'}
@@ -1188,6 +1254,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.2':
     resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1204,6 +1276,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.23.1':
     resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
     engines: {node: '>=18'}
@@ -1212,6 +1290,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.2':
     resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1228,6 +1312,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.23.1':
     resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
     engines: {node: '>=18'}
@@ -1236,6 +1326,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.2':
     resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1252,8 +1348,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1270,6 +1378,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.23.1':
     resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
     engines: {node: '>=18'}
@@ -1278,6 +1392,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1294,8 +1414,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.2':
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1312,6 +1444,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.23.1':
     resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
     engines: {node: '>=18'}
@@ -1320,6 +1458,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1336,6 +1480,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.23.1':
     resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
     engines: {node: '>=18'}
@@ -1344,6 +1494,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.2':
     resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1674,103 +1830,128 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.47':
     resolution: {integrity: sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw==}
 
-  '@rollup/rollup-android-arm-eabi@4.46.2':
-    resolution: {integrity: sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==}
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.46.2':
-    resolution: {integrity: sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==}
+  '@rollup/rollup-android-arm64@4.61.1':
+    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.46.2':
-    resolution: {integrity: sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==}
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.46.2':
-    resolution: {integrity: sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==}
+  '@rollup/rollup-darwin-x64@4.61.1':
+    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.46.2':
-    resolution: {integrity: sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==}
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.46.2':
-    resolution: {integrity: sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==}
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
-    resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.46.2':
-    resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.46.2':
-    resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.46.2':
-    resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
-    resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.46.2':
-    resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.46.2':
-    resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.46.2':
-    resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.46.2':
-    resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.46.2':
-    resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.46.2':
-    resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.46.2':
-    resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.46.2':
-    resolution: {integrity: sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==}
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.46.2':
-    resolution: {integrity: sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==}
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
     cpu: [x64]
     os: [win32]
 
@@ -1964,6 +2145,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
@@ -2644,6 +2828,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -2989,6 +3178,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -3131,8 +3325,8 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -3519,8 +3713,8 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
-  rollup@4.46.2:
-    resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
+  rollup@4.61.1:
+    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -3701,6 +3895,10 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -3826,8 +4024,8 @@ packages:
     peerDependencies:
       vite: '>=7'
 
-  vite@7.3.0:
-    resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4491,10 +4689,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.23.1':
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.23.1':
@@ -4503,10 +4707,16 @@ snapshots:
   '@esbuild/android-arm@0.27.2':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.23.1':
     optional: true
 
   '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.23.1':
@@ -4515,10 +4725,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.23.1':
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.23.1':
@@ -4527,10 +4743,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.23.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.23.1':
@@ -4539,10 +4761,16 @@ snapshots:
   '@esbuild/linux-arm64@0.27.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.23.1':
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.23.1':
@@ -4551,10 +4779,16 @@ snapshots:
   '@esbuild/linux-ia32@0.27.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.23.1':
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.23.1':
@@ -4563,10 +4797,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.23.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.23.1':
@@ -4575,10 +4815,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.23.1':
     optional: true
 
   '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.23.1':
@@ -4587,7 +4833,13 @@ snapshots:
   '@esbuild/linux-x64@0.27.2':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.23.1':
@@ -4596,10 +4848,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.23.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.23.1':
@@ -4608,7 +4866,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.23.1':
@@ -4617,10 +4881,16 @@ snapshots:
   '@esbuild/sunos-x64@0.27.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/win32-arm64@0.23.1':
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.23.1':
@@ -4629,10 +4899,16 @@ snapshots:
   '@esbuild/win32-ia32@0.27.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.23.1':
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@floating-ui/core@1.6.9':
@@ -5017,7 +5293,7 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
-  '@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@5.0.1))(react@19.2.1)':
+  '@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@standard-schema/utils': 0.3.0
@@ -5031,64 +5307,79 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.47': {}
 
-  '@rollup/rollup-android-arm-eabi@4.46.2':
+  '@rollup/rollup-android-arm-eabi@4.61.1':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.46.2':
+  '@rollup/rollup-android-arm64@4.61.1':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.46.2':
+  '@rollup/rollup-darwin-arm64@4.61.1':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.46.2':
+  '@rollup/rollup-darwin-x64@4.61.1':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.46.2':
+  '@rollup/rollup-freebsd-arm64@4.61.1':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.46.2':
+  '@rollup/rollup-freebsd-x64@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.46.2':
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.46.2':
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.46.2':
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.46.2':
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.46.2':
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.46.2':
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.46.2':
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.46.2':
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.46.2':
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.46.2':
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.46.2':
+  '@rollup/rollup-linux-x64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.46.2':
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
     optional: true
 
   '@sentry-internal/browser-utils@10.35.0':
@@ -5338,6 +5629,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/estree@1.0.9': {}
+
   '@types/mysql@2.15.27':
     dependencies:
       '@types/node': 24.0.8
@@ -5380,20 +5673,20 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@universal-deploy/netlify@0.2.2(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))':
+  '@universal-deploy/netlify@0.2.2(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))':
     dependencies:
       '@universal-deploy/store': 0.2.1(srvx@0.11.15)
-      vite: 7.3.0(@types/node@24.0.8)
+      vite: 7.3.5(@types/node@24.0.8)
     transitivePeerDependencies:
       - srvx
 
-  '@universal-deploy/node@0.1.6(vite@7.3.0(@types/node@24.0.8))':
+  '@universal-deploy/node@0.1.6(vite@7.3.5(@types/node@24.0.8))':
     dependencies:
       '@universal-deploy/store': 0.2.1(srvx@0.11.15)
       magic-string: 0.30.21
       srvx: 0.11.15
     optionalDependencies:
-      vite: 7.3.0(@types/node@24.0.8)
+      vite: 7.3.5(@types/node@24.0.8)
 
   '@universal-deploy/store@0.2.1(srvx@0.11.15)':
     dependencies:
@@ -5401,16 +5694,16 @@ snapshots:
     optionalDependencies:
       srvx: 0.11.15
 
-  '@universal-deploy/vite@0.1.9(hono@4.12.14)(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))':
+  '@universal-deploy/vite@0.1.9(hono@4.12.14)(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))':
     dependencies:
-      '@universal-deploy/netlify': 0.2.2(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
-      '@universal-deploy/node': 0.1.6(vite@7.3.0(@types/node@24.0.8))
+      '@universal-deploy/netlify': 0.2.2(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
+      '@universal-deploy/node': 0.1.6(vite@7.3.5(@types/node@24.0.8))
       '@universal-deploy/store': 0.2.1(srvx@0.11.15)
       '@universal-middleware/express': 0.4.26(hono@4.12.14)(srvx@0.11.15)
       magic-string: 0.30.21
       rou3: 0.8.1
     optionalDependencies:
-      vite: 7.3.0(@types/node@24.0.8)
+      vite: 7.3.5(@types/node@24.0.8)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -5459,7 +5752,7 @@ snapshots:
       - hono
       - srvx
 
-  '@vitejs/plugin-react@5.1.1(vite@7.3.0(@types/node@24.0.8))':
+  '@vitejs/plugin-react@5.1.1(vite@7.3.5(@types/node@24.0.8))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -5467,7 +5760,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.47
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.0(@types/node@24.0.8)
+      vite: 7.3.5(@types/node@24.0.8)
     transitivePeerDependencies:
       - supports-color
 
@@ -5479,13 +5772,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.0(@types/node@24.0.8))':
+  '@vitest/mocker@3.2.4(vite@7.3.5(@types/node@24.0.8))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.0(@types/node@24.0.8)
+      vite: 7.3.5(@types/node@24.0.8)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6387,6 +6680,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -6728,6 +7050,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.12: {}
+
   neo-async@2.6.2: {}
 
   node-fetch@2.7.0:
@@ -6847,9 +7171,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.6:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7298,30 +7622,35 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
-  rollup@4.46.2:
+  rollup@4.61.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.46.2
-      '@rollup/rollup-android-arm64': 4.46.2
-      '@rollup/rollup-darwin-arm64': 4.46.2
-      '@rollup/rollup-darwin-x64': 4.46.2
-      '@rollup/rollup-freebsd-arm64': 4.46.2
-      '@rollup/rollup-freebsd-x64': 4.46.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.46.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.46.2
-      '@rollup/rollup-linux-arm64-gnu': 4.46.2
-      '@rollup/rollup-linux-arm64-musl': 4.46.2
-      '@rollup/rollup-linux-loongarch64-gnu': 4.46.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.46.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.46.2
-      '@rollup/rollup-linux-riscv64-musl': 4.46.2
-      '@rollup/rollup-linux-s390x-gnu': 4.46.2
-      '@rollup/rollup-linux-x64-gnu': 4.46.2
-      '@rollup/rollup-linux-x64-musl': 4.46.2
-      '@rollup/rollup-win32-arm64-msvc': 4.46.2
-      '@rollup/rollup-win32-ia32-msvc': 4.46.2
-      '@rollup/rollup-win32-x64-msvc': 4.46.2
+      '@rollup/rollup-android-arm-eabi': 4.61.1
+      '@rollup/rollup-android-arm64': 4.61.1
+      '@rollup/rollup-darwin-arm64': 4.61.1
+      '@rollup/rollup-darwin-x64': 4.61.1
+      '@rollup/rollup-freebsd-arm64': 4.61.1
+      '@rollup/rollup-freebsd-x64': 4.61.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
+      '@rollup/rollup-linux-arm64-gnu': 4.61.1
+      '@rollup/rollup-linux-arm64-musl': 4.61.1
+      '@rollup/rollup-linux-loong64-gnu': 4.61.1
+      '@rollup/rollup-linux-loong64-musl': 4.61.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
+      '@rollup/rollup-linux-ppc64-musl': 4.61.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
+      '@rollup/rollup-linux-riscv64-musl': 4.61.1
+      '@rollup/rollup-linux-s390x-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-musl': 4.61.1
+      '@rollup/rollup-openbsd-x64': 4.61.1
+      '@rollup/rollup-openharmony-arm64': 4.61.1
+      '@rollup/rollup-win32-arm64-msvc': 4.61.1
+      '@rollup/rollup-win32-ia32-msvc': 4.61.1
+      '@rollup/rollup-win32-x64-gnu': 4.61.1
+      '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
   rou3@0.8.1: {}
@@ -7471,6 +7800,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
@@ -7558,7 +7892,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vike@0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8)):
+  vike@0.4.259(hono@4.12.14)(react-streaming@0.4.16(react@19.2.1))(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8)):
     dependencies:
       '@babel/core': 7.28.5
       '@babel/types': 7.28.5
@@ -7567,7 +7901,7 @@ snapshots:
       '@brillout/picocolors': 1.0.30
       '@brillout/vite-plugin-server-entry': 0.7.18
       '@universal-deploy/store': 0.2.1(srvx@0.11.15)
-      '@universal-deploy/vite': 0.1.9(hono@4.12.14)(srvx@0.11.15)(vite@7.3.0(@types/node@24.0.8))
+      '@universal-deploy/vite': 0.1.9(hono@4.12.14)(srvx@0.11.15)(vite@7.3.5(@types/node@24.0.8))
       '@universal-middleware/core': 0.4.17(hono@4.12.14)(srvx@0.11.15)
       '@universal-middleware/node': 0.1.0(hono@4.12.14)(srvx@0.11.15)
       cac: 6.7.14
@@ -7581,10 +7915,10 @@ snapshots:
       sirv: 3.0.2
       source-map-support: 0.5.21
       tinyglobby: 0.2.16
-      vite-plugin-wrapper: 0.1.0(vite@7.3.0(@types/node@24.0.8))
+      vite-plugin-wrapper: 0.1.0(vite@7.3.5(@types/node@24.0.8))
     optionalDependencies:
       react-streaming: 0.4.16(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      vite: 7.3.0(@types/node@24.0.8)
+      vite: 7.3.5(@types/node@24.0.8)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -7603,7 +7937,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.0(@types/node@24.0.8)
+      vite: 7.3.5(@types/node@24.0.8)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -7618,18 +7952,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-wrapper@0.1.0(vite@7.3.0(@types/node@24.0.8)):
+  vite-plugin-wrapper@0.1.0(vite@7.3.5(@types/node@24.0.8)):
     dependencies:
-      vite: 7.3.0(@types/node@24.0.8)
+      vite: 7.3.5(@types/node@24.0.8)
 
-  vite@7.3.0(@types/node@24.0.8):
+  vite@7.3.5(@types/node@24.0.8):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
-      rollup: 4.46.2
-      tinyglobby: 0.2.16
+      postcss: 8.5.15
+      rollup: 4.61.1
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.0.8
       fsevents: 2.3.3
@@ -7638,7 +7972,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.0(@types/node@24.0.8))
+      '@vitest/mocker': 3.2.4(vite@7.3.5(@types/node@24.0.8))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -7656,7 +7990,7 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.0(@types/node@24.0.8)
+      vite: 7.3.5(@types/node@24.0.8)
       vite-node: 3.2.4(@types/node@24.0.8)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
 ## Summary

  Patches dependency security vulnerabilities flagged by Dependabot across the monorepo.

  ### 1. devalue — prototype pollution (`vike-react-query`)
  Bumps `devalue` from `^4.3.2` to `^5.6.4` (resolves to `5.8.1`).

  - Fixes the prototype-pollution advisory (fixed in devalue ≥ 5.6.4).
  - `vike-react-query` only uses `uneval` from devalue (`src/integration/StreamedHydration.tsx`), whose API is unchanged in v5 — non-breaking.

  ### 2. vite — 3 CVEs (all packages + examples)
  Bumps `vite` from `^7.3.0` to `^7.3.5` (resolves to `7.3.5`).

  Fixes:
  - **CVE-2026-39363** (7.5) — Arbitrary File Read via Vite Dev Server WebSocket
  - **CVE-2026-39364** (7.5) — `server.fs.deny` bypass with queries
  - **CVE-2026-39365** (5.3) — Path Traversal in Optimized Deps `.map` handling

  Stays on the vite 7 major line to keep the `@vitejs/plugin-react` peer dependency satisfied (vite 8 would break it).

  ## Test plan
  - [x] `pnpm install` — lockfile updated, single deduped `vite@7.3.5`
  - [x] `vike-react-query` builds (`tsc`) and unit tests pass (9/9)
  - [x] `vike-react` builds (`tsc`)
