### PR TITLE
chore: add Renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitScopeDisabled",
+    "group:monorepos",
+    ":dependencyDashboard"
+  ],
+  "timezone": "Europe/Berlin",
+  "schedule": ["before 6am on monday"],
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "packageRules": [
+    {
+      "description": "Group all non-major devDependency updates into a single PR",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "devDependencies (non-major)"
+    },
+    {
+      "description": "Group React ecosystem together",
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ],
+      "groupName": "react"
+    },
+    {
+      "description": "Group the Vite ecosystem together",
+      "matchPackageNames": ["vite", "@vitejs/plugin-react", "vitest"],
+      "groupName": "vite"
+    },
+    {
+      "description": "Keep peerDependency ranges wide - require manual review",
+      "matchDepTypes": ["peerDependencies"],
+      "enabled": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "schedule": ["at any time"],
+    "prCreation": "immediate"
+  },
+  "osvVulnerabilityAlerts": true
+}


### PR DESCRIPTION
 ## Why

  This repo currently has **no automated dependency management** — no Renovate, no
  Dependabot config. Vulnerabilities and outdated deps are only caught manually
  (e.g. the recent devalue prototype-pollution and the three vite CVEs, which had
  to be found and patched by hand across 16 packages).

  Renovate fixes that by:

  - **Catching security issues automatically.** It raises a PR the moment a CVE is published for any dependency — the devalue/vite issues would have been surfaced without anyone watching Dependabot alerts.
  - **Keeping the monorepo consistent.** `vite` is declared in 16 of the 18 manifests; Renovate bumps it everywhere in a single PR (exactly the manual edit we just did) instead of letting versions drift apart.
  - **Reducing noise.** Related updates are grouped, so maintainers review a few meaningful PRs per week rather than one PR per dependency.

  It auto-discovers **all 18 `package.json` files** (root + 10 packages + 7 examples) and the single `pnpm-lock.yaml`, so coverage is complete with no per-package setup.

  ## What this PR adds

  A single `renovate.json` at the repo root:

  | Area | Behavior |
  |------|----------|
  | Commits | `chore(deps): …` — matches the repo's conventional-commit style |
  | Security | `vulnerabilityAlerts` + `osvVulnerabilityAlerts` → PRs raised **immediately, any time**, labeled `security` |
  | Grouping | Non-major devDeps → one PR; `react`/`react-dom`/`@types/*` → one PR; `vite`/`@vitejs/plugin-react`/`vitest` → one PR |
  | peerDependencies | Updates **disabled** — ranges on published packages are intentionally wide |
  | Range strategy | `bump` — updates the `package.json` range *and* the lockfile (e.g. `^7.3.0` → `^7.3.5`) |
  | Schedule | Weekly (Mon before 6am, Europe/Berlin) + `lockFileMaintenance` |
  | Visibility | Dependency Dashboard issue tracks everything pending |

  Config validated with `renovate-config-validator` ✅

  ## Setup steps (required to activate)

  Renovate is a GitHub App — merging this file alone does nothing until the app is
  installed.

  1. **Install the app:** go to https://github.com/apps/renovate and click
     *Install / Configure*.
  2. **Grant repo access:** select this repository (or "All repositories" for the
     org/account).
  3. **Merge this PR** so `renovate.json` is on the default branch.
  4. **Onboarding PR:** Renovate opens a "Configure Renovate" PR. Because a config
     already exists, it skips the defaults and just confirms detection — review the
     listed dependencies and merge it.
  5. **Done.** Renovate begins raising update PRs on schedule, and security PRs
     immediately. Track pending work via the auto-created **Dependency Dashboard**
     issue.

  ### Optional follow-ups
  - Exclude demo apps from updates: add `"ignorePaths": ["examples/**"]`.
  - Enable auto-merge for low-risk updates (e.g. devDeps patch/minor) once you trust the pipeline.
  - Adjust `timezone` / `schedule` to your preference.

