### PR TITLE
fix: use `@brillout/json-serializer` instead of `devalue` (#220)

### DIFF
--- a/packages/vike-react-query/package.json
+++ b/packages/vike-react-query/package.json
@@ -45,7 +45,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "devalue": "^4.3.2",
+    "@brillout/json-serializer": "^0.5.23",
     "react-error-boundary": "^4.0.12"
   },
   "typesVersions": {

--- a/packages/vike-react-query/package.json
+++ b/packages/vike-react-query/package.json
@@ -45,7 +45,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@brillout/json-serializer": "^0.5.23",
+    "@brillout/json-serializer": "^0.5.25",
     "react-error-boundary": "^4.0.12"
   },
   "typesVersions": {

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -69,7 +69,9 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
       )
       // `serialized` is already escaped by serialize() (htmlScriptSafe), so it contains no `<` and can't break out of
       // the <script> tag; JSON.stringify() embeds it as a JS string literal that evaluates back to `serialized`.
-      stream.injectToStream(`<script class="_rqd_"${nonceAttr}>_rqd_.push(${JSON.stringify(serialized)});_rqc_()</script>`)
+      stream.injectToStream(
+        `<script class="_rqd_"${nonceAttr}>_rqd_.push(${JSON.stringify(serialized)});_rqc_()</script>`,
+      )
     })
 
     // Unsubscribe

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -67,10 +67,12 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
           shouldDehydrateQuery: (query) => query.queryHash === event.query.queryHash,
         }),
       )
-      // `serialized` is already escaped by serialize() (htmlScriptSafe), so it contains no `<` and can't break out of
-      // the <script> tag; JSON.stringify() embeds it as a JS string literal that evaluates back to `serialized`.
+      // Inject the data as an inert <script type="application/json"> block, immediately followed by a static <script>
+      // that reads it back via its `previousElementSibling`. The arbitrary data thus lives only in the inert block,
+      // never inside an executable <script>. Both are injected together so the pairing is obvious.
       stream.injectToStream(
-        `<script class="_rqd_"${nonceAttr}>_rqd_.push(${JSON.stringify(serialized)});_rqc_()</script>`,
+        `<script type="application/json" class="_rqd_">${serialized}</script>` +
+          `<script class="_rqd_"${nonceAttr}>_rqd_.push(document.currentScript.previousElementSibling.textContent);_rqc_()</script>`,
       )
     })
 

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -67,9 +67,6 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
           shouldDehydrateQuery: (query) => query.queryHash === event.query.queryHash,
         }),
       )
-      // Inject the data as an inert <script type="application/json"> block, immediately followed by a static <script>
-      // that reads it back via its `previousElementSibling`. The arbitrary data thus lives only in the inert block,
-      // never inside an executable <script>. Both are injected together so the pairing is obvious.
       stream.injectToStream(
         `<script type="application/json" class="_rqd_">${serialized}</script>` +
           `<script class="_rqd_"${nonceAttr}>_rqd_.push(document.currentScript.previousElementSibling.textContent);_rqc_()</script>`,

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -3,16 +3,45 @@ export { StreamedHydration }
 import type { QueryClient } from '@tanstack/react-query'
 import { dehydrate, hydrate, type DehydratedState } from '@tanstack/react-query'
 import { assert } from '../utils/assert.js'
-import { uneval } from 'devalue'
+import { stringify } from '@brillout/json-serializer/stringify'
+import { parse } from '@brillout/json-serializer/parse'
 import type { ReactNode } from 'react'
 import { useStream } from 'react-streaming'
 import { usePageContext } from 'vike-react/usePageContext'
 
 declare global {
   interface Window {
-    _rqd_?: { push: (entry: DehydratedState) => void } | DehydratedState[]
+    // The dehydrated state is serialized to a string (using @brillout/json-serializer) and parsed on the client.
+    _rqd_?: { push: (entry: string) => void } | string[]
     _rqc_?: () => void
   }
+}
+
+// We use @brillout/json-serializer (instead of devalue) to serialize the dehydrated state, see
+// https://github.com/vikejs/vike-react/pull/220
+//
+// Unlike devalue's uneval(), json-serializer's stringify() doesn't escape the serialized string for safe injection
+// into a <script> tag. We therefore escape it ourselves (replacing `/` with `\/` prevents `</script>` from breaking
+// out of the tag), the same way Vike does it for pageContext:
+// https://github.com/vikejs/vike/blob/main/packages/vike/src/server/runtime/renderPageServer/html/serializeContext.ts
+function serializeDehydratedState(value: DehydratedState): string {
+  return stringify(value, {
+    forbidReactElements: true,
+    replacer(_key, value) {
+      if (typeof value === 'string') {
+        return { replacement: value.replaceAll('/', '\\/'), resolved: false }
+      }
+    },
+  })
+}
+function parseDehydratedState(serialized: string): DehydratedState {
+  return parse(serialized, {
+    reviver(_key, value) {
+      if (typeof value === 'string') {
+        return { replacement: value.replaceAll('\\/', '/'), resolved: false }
+      }
+    },
+  }) as DehydratedState
 }
 
 /**
@@ -61,12 +90,15 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
       }
       if (!shouldSend) return
 
+      const serialized = serializeDehydratedState(
+        dehydrate(client, {
+          shouldDehydrateQuery: (query) => query.queryHash === event.query.queryHash,
+        }),
+      )
+      // JSON.stringify() embeds the serialized string as a JS string literal (the escaping done in
+      // serializeDehydratedState() keeps `</script>` from breaking out of the <script> tag).
       stream.injectToStream(
-        `<script class="_rqd_"${nonceAttr}>_rqd_.push(${uneval(
-          dehydrate(client, {
-            shouldDehydrateQuery: (query) => query.queryHash === event.query.queryHash,
-          }),
-        )});_rqc_()</script>`,
+        `<script class="_rqd_"${nonceAttr}>_rqd_.push(${JSON.stringify(serialized)});_rqc_()</script>`,
       )
     })
 
@@ -80,8 +112,8 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
   }
 
   if (globalThis.__VIKE__IS_CLIENT && Array.isArray(window._rqd_)) {
-    const onEntry = (entry: DehydratedState) => {
-      hydrate(client, entry)
+    const onEntry = (entry: string) => {
+      hydrate(client, parseDehydratedState(entry))
     }
     for (const entry of window._rqd_) {
       onEntry(entry)

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -69,7 +69,7 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
       )
       stream.injectToStream(
         [
-          `<script type="application/json" class="_rqd_"${nonceAttr}>${serialized}</script>`,
+          `<script class="_rqd_" type="application/json"${nonceAttr}>${serialized}</script>`,
           `<script class="_rqd_"${nonceAttr}>_rqd_.push(document.currentScript.previousElementSibling.textContent);_rqc_()</script>`,
         ].join(''),
       )

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -95,9 +95,6 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
   return children
 }
 
-// `htmlScriptSafe` makes @brillout/json-serializer escape `<` (so a `</script>` in the data can't break out of the
-// <script> tag — XSS, reproduction: https://jsfiddle.net/wy6zgn37/) and `/` (so search engines don't crawl URLs in
-// the state). parse() transparently decodes both.
 function serialize(state: DehydratedState): string {
   return stringify(state, { forbidReactElements: true, htmlScriptSafe: true })
 }

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -11,10 +11,8 @@ import { usePageContext } from 'vike-react/usePageContext'
 
 declare global {
   interface Window {
-    // Queue of serialized dehydrated states (the textContent of the streamed <script type="application/json"> blocks).
-    _rqd_?: string[]
-    // Consumes a streamed block: reads the <script type="application/json"> preceding the given trigger <script>.
-    _rqc_?: (trigger: HTMLScriptElement) => void
+    _rqd_?: { push: (entry: string) => void } | string[]
+    _rqc_?: () => void
   }
 }
 
@@ -34,11 +32,10 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
     // No need to escape the injected HTML — see https://github.com/vikejs/vike/blob/36201ddad5f5b527b244b24d548014ec86c204e4/packages/vike/src/server/runtime/renderPageServer/csp.ts#L45
     const nonceAttr = pageContext.cspNonce ? ` nonce="${pageContext.cspNonce}"` : ''
 
-    // Bootstrap: until the client runtime takes over, `_rqc_()` reads each streamed block and queues it into `_rqd_`.
-    // This <script> contains no user data (the data lives in the inert <script type="application/json"> blocks below),
-    // so it can't be an injection vector.
     stream.injectToStream(
-      `<script${nonceAttr}>_rqd_=[];_rqc_=(s)=>{var b=s.previousElementSibling;_rqd_.push(b.textContent);b.remove();s.remove()};document.currentScript.remove()</script>`,
+      `<script class="_rqd_"${nonceAttr}>_rqd_=[];_rqc_=()=>{Array.from(
+        document.getElementsByClassName("_rqd_")
+      ).forEach((e) => e.remove())};_rqc_()</script>`,
     )
 
     const alreadySent = new Set<string>()
@@ -70,13 +67,9 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
           shouldDehydrateQuery: (query) => query.queryHash === event.query.queryHash,
         }),
       )
-      // Inject the data as an inert <script type="application/json"> block, then a fully static <script> that reads it
-      // synchronously (via `document.currentScript.previousElementSibling`). Arbitrary data thus stays confined to the
-      // inert block (escaped by serialize()) and never ends up inside an executable <script>.
-      stream.injectToStream(
-        `<script type="application/json">${serialized}</script>` +
-          `<script${nonceAttr}>_rqc_(document.currentScript)</script>`,
-      )
+      // `serialized` is already escaped by serialize() (htmlScriptSafe), so it contains no `<` and can't break out of
+      // the <script> tag; JSON.stringify() embeds it as a JS string literal that evaluates back to `serialized`.
+      stream.injectToStream(`<script class="_rqd_"${nonceAttr}>_rqd_.push(${JSON.stringify(serialized)});_rqc_()</script>`)
     })
 
     // Unsubscribe
@@ -89,27 +82,20 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
   }
 
   if (globalThis.__VIKE__IS_CLIENT && Array.isArray(window._rqd_)) {
-    const onEntry = (serialized: string) => hydrate(client, deserialize(serialized))
-    // Hydrate the blocks streamed before the client runtime took over.
-    window._rqd_.forEach(onEntry)
-    window._rqd_ = undefined
-    // Hydrate live for blocks streamed afterwards.
-    window._rqc_ = (trigger) => {
-      const block = trigger.previousElementSibling
-      assert(block)
-      const json = block.textContent
-      assert(json)
-      onEntry(json)
-      block.remove()
-      trigger.remove()
+    const onEntry = (entry: string) => {
+      hydrate(client, deserialize(entry))
     }
+    for (const entry of window._rqd_) {
+      onEntry(entry)
+    }
+    window._rqd_ = { push: onEntry }
   }
   return children
 }
 
 // `htmlScriptSafe` makes @brillout/json-serializer escape `<` (so a `</script>` in the data can't break out of the
-// inert <script type="application/json"> block — XSS, reproduction: https://jsfiddle.net/wy6zgn37/) and `/` (so search
-// engines don't crawl URLs contained in the state). parse() transparently decodes both.
+// <script> tag — XSS, reproduction: https://jsfiddle.net/wy6zgn37/) and `/` (so search engines don't crawl URLs in
+// the state). parse() transparently decodes both.
 function serialize(state: DehydratedState): string {
   return stringify(state, { forbidReactElements: true, htmlScriptSafe: true })
 }

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -107,12 +107,11 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
   return children
 }
 
-// We use @brillout/json-serializer to serialize the dehydrated state into the inert <script type="application/json">
-// block. We escape, in the JSON itself (both are valid JSON escapes that parse() decodes):
-// - `<` so the data can't break out of the <script> block (e.g. `</script>`), reproduction: https://jsfiddle.net/wy6zgn37/
-// - `/` so that search engines don't crawl URLs contained in the state (like Vike, see https://github.com/vikejs/vike/pull/2603)
+// `htmlScriptSafe` makes @brillout/json-serializer escape `<` (so a `</script>` in the data can't break out of the
+// inert <script type="application/json"> block — XSS, reproduction: https://jsfiddle.net/wy6zgn37/) and `/` (so search
+// engines don't crawl URLs contained in the state). parse() transparently decodes both.
 function serialize(state: DehydratedState): string {
-  return stringify(state, { forbidReactElements: true }).replaceAll('<', '\\u003c').replaceAll('/', '\\/')
+  return stringify(state, { forbidReactElements: true, htmlScriptSafe: true })
 }
 function deserialize(serialized: string): DehydratedState {
   return parse(serialized) as DehydratedState

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -69,7 +69,7 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
       )
       stream.injectToStream(
         [
-          `<script type="application/json" class="_rqd_">${serialized}</script>`,
+          `<script type="application/json" class="_rqd_"${nonceAttr}>${serialized}</script>`,
           `<script class="_rqd_"${nonceAttr}>_rqd_.push(document.currentScript.previousElementSibling.textContent);_rqc_()</script>`,
         ].join(''),
       )

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -11,8 +11,10 @@ import { usePageContext } from 'vike-react/usePageContext'
 
 declare global {
   interface Window {
-    _rqd_?: { push: (entry: string) => void } | string[]
-    _rqc_?: () => void
+    // Queue of serialized dehydrated states (the textContent of the streamed <script type="application/json"> blocks).
+    _rqd_?: string[]
+    // Consumes a streamed block: reads the <script type="application/json"> preceding the given trigger <script>.
+    _rqc_?: (trigger: HTMLScriptElement) => void
   }
 }
 
@@ -32,10 +34,11 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
     // No need to escape the injected HTML — see https://github.com/vikejs/vike/blob/36201ddad5f5b527b244b24d548014ec86c204e4/packages/vike/src/server/runtime/renderPageServer/csp.ts#L45
     const nonceAttr = pageContext.cspNonce ? ` nonce="${pageContext.cspNonce}"` : ''
 
+    // Bootstrap: until the client runtime takes over, `_rqc_()` reads each streamed block and queues it into `_rqd_`.
+    // This <script> contains no user data (the data lives in the inert <script type="application/json"> blocks below),
+    // so it can't be an injection vector.
     stream.injectToStream(
-      `<script class="_rqd_"${nonceAttr}>_rqd_=[];_rqc_=()=>{Array.from(
-        document.getElementsByClassName("_rqd_")
-      ).forEach((e) => e.remove())};_rqc_()</script>`,
+      `<script${nonceAttr}>_rqd_=[];_rqc_=(s)=>{var b=s.previousElementSibling;_rqd_.push(b.textContent);b.remove();s.remove()};document.currentScript.remove()</script>`,
     )
 
     const alreadySent = new Set<string>()
@@ -67,11 +70,13 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
           shouldDehydrateQuery: (query) => query.queryHash === event.query.queryHash,
         }),
       )
-      // Escape the serialized state before injecting it into the <script> tag (JS reverses both escapes on eval):
-      // - `<` so the data can't break out of the tag (e.g. `</script>`)
-      // - `/` so that search engines don't crawl URLs contained in the state (like Vike, see https://github.com/vikejs/vike/pull/2603)
-      const script = JSON.stringify(serialized).replaceAll('<', '\\u003c').replaceAll('/', '\\/')
-      stream.injectToStream(`<script class="_rqd_"${nonceAttr}>_rqd_.push(${script});_rqc_()</script>`)
+      // Inject the data as an inert <script type="application/json"> block, then a fully static <script> that reads it
+      // synchronously (via `document.currentScript.previousElementSibling`). Arbitrary data thus stays confined to the
+      // inert block (escaped by serialize()) and never ends up inside an executable <script>.
+      stream.injectToStream(
+        `<script type="application/json">${serialized}</script>` +
+          `<script${nonceAttr}>_rqc_(document.currentScript)</script>`,
+      )
     })
 
     // Unsubscribe
@@ -84,19 +89,30 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
   }
 
   if (globalThis.__VIKE__IS_CLIENT && Array.isArray(window._rqd_)) {
-    const onEntry = (entry: string) => {
-      hydrate(client, deserialize(entry))
+    const onEntry = (serialized: string) => hydrate(client, deserialize(serialized))
+    // Hydrate the blocks streamed before the client runtime took over.
+    window._rqd_.forEach(onEntry)
+    window._rqd_ = undefined
+    // Hydrate live for blocks streamed afterwards.
+    window._rqc_ = (trigger) => {
+      const block = trigger.previousElementSibling
+      assert(block)
+      const json = block.textContent
+      assert(json)
+      onEntry(json)
+      block.remove()
+      trigger.remove()
     }
-    for (const entry of window._rqd_) {
-      onEntry(entry)
-    }
-    window._rqd_ = { push: onEntry }
   }
   return children
 }
 
+// We use @brillout/json-serializer to serialize the dehydrated state into the inert <script type="application/json">
+// block. We escape, in the JSON itself (both are valid JSON escapes that parse() decodes):
+// - `<` so the data can't break out of the <script> block (e.g. `</script>`)
+// - `/` so that search engines don't crawl URLs contained in the state (like Vike, see https://github.com/vikejs/vike/pull/2603)
 function serialize(state: DehydratedState): string {
-  return stringify(state, { forbidReactElements: true })
+  return stringify(state, { forbidReactElements: true }).replaceAll('<', '\\u003c').replaceAll('/', '\\/')
 }
 function deserialize(serialized: string): DehydratedState {
   return parse(serialized) as DehydratedState

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -67,8 +67,10 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
           shouldDehydrateQuery: (query) => query.queryHash === event.query.queryHash,
         }),
       )
-      // We escape `<` so that the serialized data can't break out of the injected <script> tag (e.g. `</script>`).
-      const script = JSON.stringify(serialized).replaceAll('<', '\\u003c')
+      // Escape the serialized state before injecting it into the <script> tag (JS reverses both escapes on eval):
+      // - `<` so the data can't break out of the tag (e.g. `</script>`)
+      // - `/` so that search engines don't crawl URLs contained in the state (like Vike, see https://github.com/vikejs/vike/pull/2603)
+      const script = JSON.stringify(serialized).replaceAll('<', '\\u003c').replaceAll('/', '\\/')
       stream.injectToStream(`<script class="_rqd_"${nonceAttr}>_rqd_.push(${script});_rqc_()</script>`)
     })
 

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -93,7 +93,6 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
   return children
 }
 
-// We use @brillout/json-serializer instead of devalue (https://github.com/vikejs/vike-react/pull/220).
 // We escape `/` so that the serialized string can't break out of the injected <script> tag (like Vike does).
 function serialize(state: DehydratedState): string {
   return stringify(state, {

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -67,9 +67,9 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
           shouldDehydrateQuery: (query) => query.queryHash === event.query.queryHash,
         }),
       )
-      stream.injectToStream(
-        `<script class="_rqd_"${nonceAttr}>_rqd_.push(${JSON.stringify(serialized)});_rqc_()</script>`,
-      )
+      // We escape `<` so that the serialized data can't break out of the injected <script> tag (e.g. `</script>`).
+      const script = JSON.stringify(serialized).replaceAll('<', '\\u003c')
+      stream.injectToStream(`<script class="_rqd_"${nonceAttr}>_rqd_.push(${script});_rqc_()</script>`)
     })
 
     // Unsubscribe
@@ -93,17 +93,9 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
   return children
 }
 
-// We escape `/` so that the serialized string can't break out of the injected <script> tag (like Vike does).
 function serialize(state: DehydratedState): string {
-  return stringify(state, {
-    forbidReactElements: true,
-    replacer: (_key, value) =>
-      typeof value === 'string' ? { replacement: value.replaceAll('/', '\\/'), resolved: false } : undefined,
-  })
+  return stringify(state, { forbidReactElements: true })
 }
 function deserialize(serialized: string): DehydratedState {
-  return parse(serialized, {
-    reviver: (_key, value) =>
-      typeof value === 'string' ? { replacement: value.replaceAll('\\/', '/'), resolved: false } : undefined,
-  }) as DehydratedState
+  return parse(serialized) as DehydratedState
 }

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -68,8 +68,10 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
         }),
       )
       stream.injectToStream(
-        `<script type="application/json" class="_rqd_">${serialized}</script>` +
+        [
+          `<script type="application/json" class="_rqd_">${serialized}</script>`,
           `<script class="_rqd_"${nonceAttr}>_rqd_.push(document.currentScript.previousElementSibling.textContent);_rqc_()</script>`,
+        ].join(''),
       )
     })
 

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -11,37 +11,9 @@ import { usePageContext } from 'vike-react/usePageContext'
 
 declare global {
   interface Window {
-    // The dehydrated state is serialized to a string (using @brillout/json-serializer) and parsed on the client.
     _rqd_?: { push: (entry: string) => void } | string[]
     _rqc_?: () => void
   }
-}
-
-// We use @brillout/json-serializer (instead of devalue) to serialize the dehydrated state, see
-// https://github.com/vikejs/vike-react/pull/220
-//
-// Unlike devalue's uneval(), json-serializer's stringify() doesn't escape the serialized string for safe injection
-// into a <script> tag. We therefore escape it ourselves (replacing `/` with `\/` prevents `</script>` from breaking
-// out of the tag), the same way Vike does it for pageContext:
-// https://github.com/vikejs/vike/blob/main/packages/vike/src/server/runtime/renderPageServer/html/serializeContext.ts
-function serializeDehydratedState(value: DehydratedState): string {
-  return stringify(value, {
-    forbidReactElements: true,
-    replacer(_key, value) {
-      if (typeof value === 'string') {
-        return { replacement: value.replaceAll('/', '\\/'), resolved: false }
-      }
-    },
-  })
-}
-function parseDehydratedState(serialized: string): DehydratedState {
-  return parse(serialized, {
-    reviver(_key, value) {
-      if (typeof value === 'string') {
-        return { replacement: value.replaceAll('\\/', '/'), resolved: false }
-      }
-    },
-  }) as DehydratedState
 }
 
 /**
@@ -90,13 +62,11 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
       }
       if (!shouldSend) return
 
-      const serialized = serializeDehydratedState(
+      const serialized = serialize(
         dehydrate(client, {
           shouldDehydrateQuery: (query) => query.queryHash === event.query.queryHash,
         }),
       )
-      // JSON.stringify() embeds the serialized string as a JS string literal (the escaping done in
-      // serializeDehydratedState() keeps `</script>` from breaking out of the <script> tag).
       stream.injectToStream(
         `<script class="_rqd_"${nonceAttr}>_rqd_.push(${JSON.stringify(serialized)});_rqc_()</script>`,
       )
@@ -113,7 +83,7 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
 
   if (globalThis.__VIKE__IS_CLIENT && Array.isArray(window._rqd_)) {
     const onEntry = (entry: string) => {
-      hydrate(client, parseDehydratedState(entry))
+      hydrate(client, deserialize(entry))
     }
     for (const entry of window._rqd_) {
       onEntry(entry)
@@ -121,4 +91,20 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
     window._rqd_ = { push: onEntry }
   }
   return children
+}
+
+// We use @brillout/json-serializer instead of devalue (https://github.com/vikejs/vike-react/pull/220).
+// We escape `/` so that the serialized string can't break out of the injected <script> tag (like Vike does).
+function serialize(state: DehydratedState): string {
+  return stringify(state, {
+    forbidReactElements: true,
+    replacer: (_key, value) =>
+      typeof value === 'string' ? { replacement: value.replaceAll('/', '\\/'), resolved: false } : undefined,
+  })
+}
+function deserialize(serialized: string): DehydratedState {
+  return parse(serialized, {
+    reviver: (_key, value) =>
+      typeof value === 'string' ? { replacement: value.replaceAll('\\/', '/'), resolved: false } : undefined,
+  }) as DehydratedState
 }

--- a/packages/vike-react-query/src/integration/StreamedHydration.tsx
+++ b/packages/vike-react-query/src/integration/StreamedHydration.tsx
@@ -109,7 +109,7 @@ function StreamedHydration({ client, children }: { client: QueryClient; children
 
 // We use @brillout/json-serializer to serialize the dehydrated state into the inert <script type="application/json">
 // block. We escape, in the JSON itself (both are valid JSON escapes that parse() decodes):
-// - `<` so the data can't break out of the <script> block (e.g. `</script>`)
+// - `<` so the data can't break out of the <script> block (e.g. `</script>`), reproduction: https://jsfiddle.net/wy6zgn37/
 // - `/` so that search engines don't crawl URLs contained in the state (like Vike, see https://github.com/vikejs/vike/pull/2603)
 function serialize(state: DehydratedState): string {
   return stringify(state, { forbidReactElements: true }).replaceAll('<', '\\u003c').replaceAll('/', '\\/')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,8 +440,8 @@ importers:
   packages/vike-react-query:
     dependencies:
       '@brillout/json-serializer':
-        specifier: ^0.5.23
-        version: 0.5.23
+        specifier: ^0.5.25
+        version: 0.5.25
       react-error-boundary:
         specifier: ^4.0.12
         version: 4.1.2(react@19.2.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,9 +439,9 @@ importers:
 
   packages/vike-react-query:
     dependencies:
-      devalue:
-        specifier: ^4.3.2
-        version: 4.3.3
+      '@brillout/json-serializer':
+        specifier: ^0.5.23
+        version: 0.5.23
       react-error-boundary:
         specifier: ^4.0.12
         version: 4.1.2(react@19.2.1)
@@ -2577,9 +2577,6 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-
-  devalue@4.3.3:
-    resolution: {integrity: sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -6283,8 +6280,6 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
-
-  devalue@4.3.3: {}
 
   dom-accessibility-api@0.5.16: {}
 


### PR DESCRIPTION
Replace devalue's `uneval` with @brillout/json-serializer for serializing the dehydrated React Query state injected during streaming.

devalue has repeatedly had advisories (e.g. the prototype-pollution one in vike-react#220) and its design is more than what we need here. We already use @brillout/json-serializer across Vike, so this keeps the serialization stack consistent.

Unlike devalue's `uneval` (which emits directly-evaluable JS escaped for `<script>` injection), json-serializer's `stringify` emits a string that's `parse`d on the client. The string is embedded as a JS string literal via `JSON.stringify`, and we escape `/` -> `\/` (reversed on parse) to keep `</script>` from breaking out of the injected tag — the same approach Vike uses for pageContext serialization.