### PR TITLE
fix(vike-react-zustand): escape SSR store state to prevent XSS & crash (#3463)

### DIFF
--- a/examples/zustand/.testRun.ts
+++ b/examples/zustand/.testRun.ts
@@ -12,6 +12,7 @@ import {
   expectLog,
   sleep,
 } from '@brillout/test-e2e'
+import { todoItemHostile } from './todoItemHostile'
 
 function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
   const isDev = cmd === 'pnpm run dev'
@@ -53,23 +54,27 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
       const html = await fetchHtml('/')
       expect(html).toContain(`<li>${buyApples}</li>`)
       expect(html).toContain(nodeVersion)
+      // The store state injected during SSR escapes hostile characters (https://github.com/vikejs/vike/issues/3463) — the raw text never occurs in the HTML: it's HTML-escaped inside <li> and JS-escaped inside the injected <script>
+      expect(html).not.toContain(todoItemHostile)
     }
     {
       const bodyText = await page.textContent('body')
       expect(bodyText).toContain(buyApples)
       expect(bodyText).toContain(nodeVersion)
-      expect(await getNumberOfItems()).toBe(2)
+      expect(await getNumberOfItems()).toBe(3)
+      // The hostile characters survive SSR store serialization + client-side hydration unchanged (https://github.com/vikejs/vike/issues/3463)
+      expect(await getTodoItemText(2)).toBe(todoItemHostile)
     }
   }
 
   test('todos - add to-do', async () => {
-    expect(await getNumberOfItems()).toBe(2)
+    expect(await getNumberOfItems()).toBe(3)
     if (isDev) await sleep(1000) // Seems to be required, otherwise the test is flaky. I don't know why.
     await page.fill('input[type="text"]', 'Buy bananas')
     await page.click('button[type="submit"]')
     const expectBananas = async () => {
       await autoRetry(async () => {
-        expect(await getNumberOfItems()).toBe(3)
+        expect(await getNumberOfItems()).toBe(4)
         expect(await page.textContent('body')).toContain('Buy bananas')
       })
     }
@@ -97,6 +102,10 @@ function testRun(cmd: 'pnpm run dev' | 'pnpm run preview') {
 
 async function getNumberOfItems() {
   return await page.evaluate(() => document.querySelectorAll('#todo-list li').length)
+}
+
+async function getTodoItemText(index: number) {
+  return await page.evaluate((i) => document.querySelectorAll('#todo-list li')[i]?.textContent, index)
 }
 
 async function testCounter(currentValue?: number) {

--- a/examples/zustand/pages/index/+data.ts
+++ b/examples/zustand/pages/index/+data.ts
@@ -3,6 +3,7 @@ export { data }
 export type Data = Awaited<ReturnType<typeof data>>
 
 import type { PageContextServer } from 'vike/types'
+import { todoItemHostile } from '../../todoItemHostile'
 
 async function data(pageContext: PageContextServer) {
   const todoItemsInitial = await fetchTodosInit()
@@ -15,5 +16,6 @@ async function fetchTodosInit() {
     //
     { text: 'Buy apples' },
     { text: `Update Node.js ${process.version} to latest version` },
+    { text: todoItemHostile },
   ]
 }

--- a/examples/zustand/todoItemHostile.ts
+++ b/examples/zustand/todoItemHostile.ts
@@ -1,0 +1,4 @@
+export { todoItemHostile }
+
+// A to-do text full of hostile characters — ensures that vike-react-zustand correctly escapes the store state it injects during SSR (https://github.com/vikejs/vike/issues/3463)
+const todoItemHostile = `Fix O'Brien's bug: escape \\ ' " </script> <!-- and \n🚀`

--- a/packages/vike-react-zustand/package.json
+++ b/packages/vike-react-zustand/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "dev": "tsc --watch",
     "build": "rimraf dist/ && tsc",
+    "test:units": "vitest run",
     "release": "release-me patch",
     "release:minor": "release-me minor",
     "release:commit": "release-me commit"
@@ -38,6 +39,7 @@
     "vike-react": "0.6.25",
     "react-streaming": "^0.4.19",
     "vite": "^7.3.0",
+    "vitest": "^3.2.4",
     "zustand": "^5.0.3"
   },
   "dependencies": {

--- a/packages/vike-react-zustand/src/getOrCreateStore.ts
+++ b/packages/vike-react-zustand/src/getOrCreateStore.ts
@@ -7,6 +7,7 @@ import type { PageContext } from 'vike/types'
 import { create as createZustand, StateCreator } from 'zustand'
 import { setPageContext } from './context.js'
 import { assert } from './utils/assert.js'
+import { escapeForJsSingleQuotedString } from './utils/escapeForJsSingleQuotedString.js'
 import { getGlobalObject } from './utils/getGlobalObject.js'
 import { sanitizeForSerialization } from './utils/sanitizeForSerialization.js'
 import { assignDeep } from './utils/assignDeep.js'
@@ -41,10 +42,13 @@ function getOrCreateStore<T>({
       const serverState = store.getInitialState()
       const transferableState = sanitizeForSerialization(serverState)
       assert(stream)
-      // No need to escape the injected HTML — see https://github.com/vikejs/vike/blob/36201ddad5f5b527b244b24d548014ec86c204e4/packages/vike/src/server/runtime/renderPageServer/csp.ts#L45
+      // No need to escape the injected nonce attribute — see https://github.com/vikejs/vike/blob/36201ddad5f5b527b244b24d548014ec86c204e4/packages/vike/src/server/runtime/renderPageServer/csp.ts#L45
       const nonceAttr = pageContext.cspNonce ? ` nonce="${pageContext.cspNonce}"` : ''
+      // The key and state are embedded inside single-quoted JavaScript string literals => they must be escaped — see escapeForJsSingleQuotedString() (https://github.com/vikejs/vike/issues/3463)
+      const keyEscaped = escapeForJsSingleQuotedString(key)
+      const stateEscaped = escapeForJsSingleQuotedString(stringify(transferableState, { htmlScriptSafe: true }))
       stream.injectToStream(
-        `<script${nonceAttr}>if(!globalThis._vikeReactZustandState)globalThis._vikeReactZustandState={};globalThis._vikeReactZustandState['${key}']='${stringify(transferableState, { htmlScriptSafe: true })}'</script>`,
+        `<script${nonceAttr}>if(!globalThis._vikeReactZustandState)globalThis._vikeReactZustandState={};globalThis._vikeReactZustandState['${keyEscaped}']='${stateEscaped}'</script>`,
       )
       pageContext._vikeReactZustandStoresServer[key] = store
       return store

--- a/packages/vike-react-zustand/src/utils/escapeForJsSingleQuotedString.spec.ts
+++ b/packages/vike-react-zustand/src/utils/escapeForJsSingleQuotedString.spec.ts
@@ -1,0 +1,105 @@
+import { parse } from '@brillout/json-serializer/parse'
+import { stringify } from '@brillout/json-serializer/stringify'
+import { describe, expect, it } from 'vitest'
+import { escapeForJsSingleQuotedString } from './escapeForJsSingleQuotedString.js'
+
+// Simulates the browser: parses `'...'` with the actual JavaScript parser
+function evalSingleQuoted(escaped: string): string {
+  return new Function(`return '${escaped}'`)() as string
+}
+
+const trickyStrings: string[] = [
+  // https://github.com/vikejs/vike/issues/3463
+  "O'Brien",
+  // XSS payloads breaking out of the single-quoted string literal
+  "'; alert(1); '",
+  "');alert(1);('",
+  "\\'-alert(1)-\\'",
+  // XSS payloads breaking out of the <script> element
+  '</script><script>alert(1)</script>',
+  '<!--<script>',
+  '--><script>alert(1)</script>',
+  // Backslashes & JSON escape sequences — mangled by the JavaScript parser if not escaped
+  'C:\\path\\to\\file',
+  'backslash-n: \\n',
+  'trailing backslash \\',
+  'line1\nline2',
+  'tab\there',
+  'carriage\rreturn',
+  'say "hi"',
+  'nul\u0000char',
+  // Line separators — a syntax error inside string literals of pre-ES2019 browsers
+  'para\u2029graph',
+  'line\u2028separator',
+  // Unicode sanity
+  'emoji 🚀 ünïcôdé 中文',
+  '',
+]
+
+describe('escapeForJsSingleQuotedString()', () => {
+  it('round-trips arbitrary strings through the JavaScript parser', () => {
+    trickyStrings.forEach((str) => {
+      expect(evalSingleQuoted(escapeForJsSingleQuotedString(str))).toBe(str)
+    })
+  })
+
+  it('never produces characters that break out of the string literal or the <script> element', () => {
+    trickyStrings.forEach((str) => {
+      const escaped = escapeForJsSingleQuotedString(str)
+      // `<` would allow `</script>` and `<!--` breakouts
+      expect(escaped).not.toContain('<')
+      // An unescaped `'` would terminate the string literal — all quotes must be preceded by a backslash
+      expect(escaped).not.toMatch(/(?<!\\)(\\\\)*'/)
+      // A raw line terminator inside a string literal is a syntax error
+      expect(escaped).not.toMatch(/[\n\r\u2028\u2029]/)
+    })
+  })
+
+  it('round-trips fuzzed strings made of hostile characters', () => {
+    const alphabet = ['\\', "'", '"', '<', '>', '/', '\n', '\r', '\u2028', '\u2029', '`', '$', '{', '}', 'a', ' ']
+    let seed = 42
+    const random = () => {
+      // Deterministic LCG => no flakiness
+      seed = (seed * 1664525 + 1013904223) % 4294967296
+      return seed / 4294967296
+    }
+    for (let i = 0; i < 1000; i++) {
+      const length = Math.floor(random() * 20)
+      const str = Array.from({ length }, () => alphabet[Math.floor(random() * alphabet.length)]).join('')
+      expect(evalSingleQuoted(escapeForJsSingleQuotedString(str))).toBe(str)
+    }
+  })
+
+  it('injected store state round-trips: stringify() => inline <script> => JavaScript parser => parse()', () => {
+    const key = "some'tricky\\key"
+    const states: unknown[] = [
+      // https://github.com/vikejs/vike/issues/3463
+      { name: "O'Brien" },
+      { xss: "'; alert(1); '" },
+      { xss: '</script><script>alert(1)</script>' },
+      { text: 'line1\nline2', quote: 'say "hi"', path: 'C:\\path\\to\\file' },
+      { nested: { list: ["it's", { deep: "d'accord" }] }, count: 42, ok: true, nil: null },
+      { map: new Map([["key'1", "value'1"]]), set: new Set(["item'1"]) },
+      { date: new Date('2026-08-14T00:00:00.000Z') },
+    ]
+    states.forEach((state) => {
+      // Mirrors the <script> injected by getOrCreateStore()
+      const scriptContent = [
+        'if(!globalThis._vikeReactZustandState)globalThis._vikeReactZustandState={};',
+        `globalThis._vikeReactZustandState['${escapeForJsSingleQuotedString(key)}']=`,
+        `'${escapeForJsSingleQuotedString(stringify(state, { htmlScriptSafe: true }))}'`,
+      ].join('')
+      // The HTML parser must never encounter `<` inside the inline <script>
+      expect(scriptContent).not.toContain('<')
+      try {
+        // Simulates the browser executing the inline <script>
+        new Function(scriptContent)()
+        // Simulates assignServerStateOptional() on the client side
+        const serverState = parse((globalThis as any)._vikeReactZustandState[key])
+        expect(serverState).toEqual(state)
+      } finally {
+        delete (globalThis as any)._vikeReactZustandState
+      }
+    })
+  })
+})

--- a/packages/vike-react-zustand/src/utils/escapeForJsSingleQuotedString.ts
+++ b/packages/vike-react-zustand/src/utils/escapeForJsSingleQuotedString.ts
@@ -1,0 +1,20 @@
+export { escapeForJsSingleQuotedString }
+
+// Escapes a string so that it can be safely embedded inside a single-quoted JavaScript string literal of an inline <script>.
+// - Without escaping `'` and `\`, values break out of the string literal — enabling XSS — or get mangled by the JavaScript parser (https://github.com/vikejs/vike/issues/3463)
+// - Escaping `<` ensures the HTML parser never encounters `</script>` nor `<!--` inside the inline <script> (the JavaScript parser decodes `\u003c` back to `<`)
+// - `\n` and `\r` never occur in JSON output, but a raw line terminator inside a JavaScript string literal is a syntax error — better safe than sorry
+// - A raw U+2028/U+2029 inside a JavaScript string literal is a syntax error in pre-ES2019 browsers
+const escapeRegex = /[\\'<\n\r\u2028\u2029]/g
+const escapeMap: Record<string, string> = {
+  '\\': '\\\\',
+  "'": "\\'",
+  '<': '\\u003c',
+  '\n': '\\n',
+  '\r': '\\r',
+  '\u2028': '\\u2028',
+  '\u2029': '\\u2029',
+}
+function escapeForJsSingleQuotedString(str: string): string {
+  return str.replace(escapeRegex, (char) => escapeMap[char]!)
+}

--- a/packages/vike-react-zustand/vitest.config.ts
+++ b/packages/vike-react-zustand/vitest.config.ts
@@ -1,0 +1,10 @@
+export { config as default }
+
+import { defineConfig } from 'vitest/config'
+
+const config = defineConfig({
+  test: {
+    // test/**/*.test.ts => @brillout/test-e2e
+    include: ['**/*.spec.*'],
+  },
+})

--- a/packages/vike-react/src/hooks/useConfig/useConfig-server.ts
+++ b/packages/vike-react/src/hooks/useConfig/useConfig-server.ts
@@ -61,9 +61,15 @@ type Stream = NonNullable<ReturnType<typeof useStreamOptional>>
 function apply(config: ConfigViaHook, stream: Stream, pageContext: PageContextServer) {
   const { title } = config
   if (title) {
-    // No need to escape the injected HTML — see https://github.com/vikejs/vike/blob/36201ddad5f5b527b244b24d548014ec86c204e4/packages/vike/src/server/runtime/renderPageServer/csp.ts#L45
+    // No need to escape the injected nonce attribute — see https://github.com/vikejs/vike/blob/36201ddad5f5b527b244b24d548014ec86c204e4/packages/vike/src/server/runtime/renderPageServer/csp.ts#L45
     const nonceAttr = pageContext.cspNonce ? ` nonce="${pageContext.cspNonce}"` : ''
-    const htmlSnippet = `<script${nonceAttr}>document.title = ${JSON.stringify(title)}</script>`
+    // JSON.stringify() produces a valid double-quoted JavaScript string literal, but `<` must additionally be escaped so that the HTML parser never encounters `</script>` nor `<!--` inside the inline <script> — the JavaScript parser decodes `\u003c` back to `<` (https://github.com/vikejs/vike/issues/3463)
+    // U+2028/U+2029 are escaped because a raw U+2028/U+2029 inside a JavaScript string literal is a syntax error in pre-ES2019 browsers
+    const titleJs = JSON.stringify(title)
+      .replace(/</g, '\\u003c')
+      .replace(/\u2028/g, '\\u2028')
+      .replace(/\u2029/g, '\\u2029')
+    const htmlSnippet = `<script${nonceAttr}>document.title = ${titleJs}</script>`
     stream.injectToStream(htmlSnippet)
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -689,6 +689,9 @@ importers:
       vite:
         specifier: ^7.3.0
         version: 7.3.0(@types/node@24.0.8)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.0.8)(jsdom@24.1.3)
       zustand:
         specifier: ^5.0.3
         version: 5.0.8(@types/react@19.2.7)(immer@10.1.3)(react@19.2.1)(use-sync-external-store@1.4.0(react@19.2.1))


### PR DESCRIPTION
Fixes vikejs/vike#3463

## Problem

`getOrCreateStore()` embeds the serialized store state inside a **single-quoted JavaScript string literal** of an inline `<script>`, without escaping it:

```ts
`...globalThis._vikeReactZustandState['${key}']='${stringify(transferableState, { htmlScriptSafe: true })}'</script>`
```

A single quote in any store value (e.g. a user name like `O'Brien`) breaks out of the string literal and crashes the page:

```
Uncaught SyntaxError: unexpected token: identifier
```

A crafted value can execute arbitrary JavaScript (XSS).

`htmlScriptSafe` from `@brillout/json-serializer` only escapes `<` and `/` — it deliberately does **not** escape `'`, because the correct escaping depends on the wrapping context. The state is wrapped in a single-quoted literal, so `'` and `\` must be escaped too. That's a fact only the injection site knows, so escaping belongs here rather than in the serializer (which is also used for the double-quoted / `type="application/json"` cases where a different escaping applies).

## Fix

Escape the key and the serialized state for the single-quoted JS string context via a small, dependency-free helper `escapeForJsSingleQuotedString()`:

- `\` → `\\` and `'` → `\'` — the actual break-out / crash fix
- `<` → `\u003c` — so the HTML parser never sees `</script>` or `<!--` inside the inline `<script>` (the JS parser decodes it back to `<`)
- `\n`, `\r`, U+2028, U+2029 → escaped — a raw line terminator inside a JS string literal is a syntax error (U+2028/U+2029 in pre-ES2019 browsers)

The value still round-trips: the browser's JS parser decodes the single-quoted literal back to the exact `stringify()` output, which `parse()` then deserializes unchanged.

### Bonus hardening (`vike-react`)

`useConfig()`'s streamed `document.title` injection (`useConfig-server.ts`) has the same class of bug. `JSON.stringify(title)` produces a valid **double-quoted** literal (so `"` and `\` are already handled), but it leaves `<` unescaped — so a title containing `</script>` breaks out of the inline `<script>`. Titles are frequently CMS/user-controlled, so this is a real XSS vector. Escaped `<` (plus U+2028/U+2029). This hunk is self-contained and can be dropped if you'd prefer to keep the PR strictly zustand-scoped.

> [!NOTE]
> No change is needed in `vike` itself. Vike's own `pageContext`/`globalContext` transfer (also used by `vike-react-redux`) and `vike-react-query`'s hydration both use the safe `<script type="application/json">` + `textContent` pattern, where the payload is never parsed as a JS string literal. The vulnerable pattern was unique to `vike-react-zustand`'s executable single-quoted inline `<script>`.

## Tests

- **Unit** (`escapeForJsSingleQuotedString.spec.ts`, new `test:units` script for the package):
  - round-trips tricky strings (`O'Brien`, break-out payloads, backslashes, `</script>`, `<!--`, newlines, U+2028/U+2029, emoji) through the actual JavaScript parser
  - asserts the escaped output never contains `<`, an unescaped `'`, or a raw line terminator
  - 1000-iteration deterministic fuzz over a hostile alphabet
  - full simulation: `stringify()` → inline `<script>` → JS parser → `parse()` equals the original state (objects, `Map`, `Set`, `Date`, nested single quotes)
- **e2e** (`examples/zustand`): the initial to-do list now contains a hostile value (`Fix O'Brien's bug: escape \ ' " </script> <!-- and \n🚀`); the test asserts the raw string never appears in the SSR HTML and that it survives SSR serialization + hydration unchanged. Both `.test-dev` and `.test-preview` pass.

### Before / after (real SSR output, verified locally)

Before — the injected script is invalid JS and throws `SyntaxError: unexpected token 'Brien'`.

After:

```html
<script>...globalThis._vikeReactZustandState['ahfbcg']='{"todoItems":[...,{"text":"Fix O\'Brien\'s bug: escape \\\\ \' \\" \\u003c\\/script> \\u003c!-- and \\n🚀"}]}'</script>
```

No literal `<`, quotes escaped, and `parse()` recovers the exact original value.


---
_Generated by [Claude Code](https://claude.ai/code/session_012ziFzKm6QvjuU9yusBCEMU)_